### PR TITLE
load vertico directory from extensions folder

### DIFF
--- a/modules/rational-completion.el
+++ b/modules/rational-completion.el
@@ -18,7 +18,7 @@ folder, otherwise delete a word"
     (backward-kill-word arg)))
 
 (require 'vertico)
-(require 'vertico-directory)
+(require 'vertico-directory "extensions/vertico-directory.el")
 
 (with-eval-after-load 'evil
   (define-key vertico-map (kbd "C-j") 'vertico-next)


### PR DESCRIPTION
When requiring the **rational-completion** I got an error that **vertico-directory** could not be required.

When checking the vertico package I noticed it was in an *extensions* subfolder which is not added to the load-path so I added the filename parameter on the require form.