### PR TITLE
(rational-default) Turn on recentf mode in rational-defaults

### DIFF
--- a/init.el
+++ b/init.el
@@ -41,6 +41,16 @@ straight.el or Guix depending on the value of
 (defvar rational-config-file (expand-file-name "config.el" rational-config-path)
   "The user's configuration file.")
 
+;; Defines the user configuration var and etc folders
+;; and ensure they exists.
+(defvar rational-config-etc-directory (expand-file-name "etc/" rational-config-path)
+  "The user's configuration etc/ folder.")
+(defvar rational-config-var-directory (expand-file-name "var/" rational-config-path)
+  "The user's configuration var/ folder.")
+
+(mkdir rational-config-etc-directory t)
+(mkdir rational-config-var-directory t)
+
 ;; Load the user configuration file if it exists
 (when (file-exists-p rational-config-file)
   (load rational-config-file nil 'nomessage))

--- a/modules/rational-defaults.el
+++ b/modules/rational-defaults.el
@@ -12,6 +12,9 @@
 ;; Use "y" and "n" to confirm/negate prompt instead of "yes" and "no"
 (fset 'yes-or-no-p 'y-or-n-p)
 
+;; Turn on recentf mode
+(recentf-mode 1)
+
 ;; Do not saves duplicates in kill-ring
 (setq kill-do-not-save-duplicates t)
 

--- a/modules/rational-defaults.el
+++ b/modules/rational-defaults.el
@@ -14,6 +14,7 @@
 
 ;; Turn on recentf mode
 (recentf-mode 1)
+(setq recentf-save-file (expand-file-name "recentf" rational-config-var-directory))
 
 ;; Do not saves duplicates in kill-ring
 (setq kill-do-not-save-duplicates t)


### PR DESCRIPTION
recentf mode is pure awesomeness and I really struggle to understand why it's not turned on by default in emacs.