### PR TITLE
(rational-completion) require consult

### DIFF
--- a/modules/rational-completion.el
+++ b/modules/rational-completion.el
@@ -20,6 +20,8 @@ folder, otherwise delete a word"
 (require 'vertico)
 (require 'vertico-directory "extensions/vertico-directory.el")
 
+(require 'consult)
+
 (with-eval-after-load 'evil
   (define-key vertico-map (kbd "C-j") 'vertico-next)
   (define-key vertico-map (kbd "C-k") 'vertico-previous)


### PR DESCRIPTION
I'm working on my `space` keybinding config and want to be kinda-flexible in case I decide to offer my config to the community, so I added the following:

```elisp
(with-eval-after-load 'evil
  (evil-set-leader 'normal " ")
  ; [...]
  "File bindings"
  (evil-define-key 'normal 'global (kbd "<leader>fs") 'save-buffer)
  (evil-define-key 'normal 'global (kbd "<leader>ff") 'find-file)
  (with-eval-after-load 'consult ;FIXME never loads
    (evil-define-key 'normal 'global (kbd "<leader>fr") 'consult-recent-file)
    )
  ; [...]
  )

```

My issue here is that because `consult` has not been `require`'d, my keybinding never registers until I use some commands that triggers consult loading.

This PR makes requires consult from the `rational-completion` so that user can rely on `with-eval-after-load` if they need to register some keybinding, or other stuff.