### PR TITLE
Jackson

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ straight/
 transient/
 eshell/
 projects
+*~

--- a/README.org
+++ b/README.org
@@ -12,84 +12,125 @@ Clone this repository to =~/.emacs.d= or =~/.config/emacs=:
 
 #+end_src
 
-This will set up the minimal configuration.  If you'd like a more fully-configured experience, copy the example-config.el to =~/.rational-emacs/config.el= and restart Emacs.
+This will set up the minimal configuration.  If you'd like a more
+fully-configured experience, copy the example-config.el to
+=~/.rational-emacs/config.el= and restart Emacs.
 
 * Principles
 
-This configuration and all associated modules intend to follow the below priniciples.
+This configuration and all associated modules intend to follow the
+below priniciples.
 
-*NOTE:* Some of these may change over time as we learn from this process.
+*NOTE:* Some of these may change over time as we learn from this
+process.
 
 ** Minimal, modular configuration
 
-The core configuration only sets up Emacs to have a cleaner presentation with sensible defaults.  It is up to the user to decide which of the various =rational-*= modules to load and when to load them.
+The core configuration only sets up Emacs to have a cleaner
+presentation with sensible defaults.  It is up to the user to decide
+which of the various =rational-*= modules to load and when to load
+them.
 
-Configuration modules should depend on other modules and the base configuration as little as possible.  When a configuration module needs to integrate with other functionality in Emacs, the standard extensibility points of each package should be used (instead of expecting our own configuration module).
+Configuration modules should depend on other modules and the base
+configuration as little as possible.  When a configuration module
+needs to integrate with other functionality in Emacs, the standard
+extensibility points of each package should be used (instead of
+expecting our own configuration module).
 
-The implication is that someone should be able to install or copy code from a =rational-*= module into their own configuration /without/ using Rational Emacs.
+The implication is that someone should be able to install or copy code
+from a =rational-*= module into their own configuration /without/
+using Rational Emacs.
 
 ** Prioritize built-in Emacs functionality
 
-Where possible, we will leverage built-in Emacs functionality instead of external packages, for example:
+Where possible, we will leverage built-in Emacs functionality instead
+of external packages, for example:
 
 - project.el instead of Projectile
-- =tab-bar-mode= instead of Perspective.el, =persp-mode=, eyebrowse, etc
-- eglot instead of lsp-mode (because eglot prioritizes built-in functionality)
+- =tab-bar-mode= instead of Perspective.el, =persp-mode=, eyebrowse,
+  etc
+- eglot instead of lsp-mode (because eglot prioritizes built-in
+  functionality)
 - *Possibly* =vc-mode= by default
 
 ** Works well in the terminal
 
-Some people prefer to use Emacs in the terminal instead of as a graphical program.  This configuration should work well in this case too!  This also enables the use of Emacs in Termux on Android.
+Some people prefer to use Emacs in the terminal instead of as a
+graphical program.  This configuration should work well in this case
+too!  This also enables the use of Emacs in Termux on Android.
 
 ** Can be integrated with a Guix configuration
 
-It should be possible to customize aspects of the Rational Emacs configuration inside of a Guix Home configuration so that things like font sizes, themes, etc can be system-specific.
+It should be possible to customize aspects of the Rational Emacs
+configuration inside of a Guix Home configuration so that things like
+font sizes, themes, etc can be system-specific.
 
-It can also use packages installed via the Guix package manager instead of =straight.el=.
+It can also use packages installed via the Guix package manager
+instead of =straight.el=.
 
 ** Works well with Chemacs2
 
-Chemacs2 is an excellent tool for enabling the use of multiple Emacs configurations simultaneously.  This configuration will behave well when used with Chemacs2 so that users can try and use different Emacs configurations as needed.
+Chemacs2 is an excellent tool for enabling the use of multiple Emacs
+configurations simultaneously.  This configuration will behave well
+when used with Chemacs2 so that users can try and use different Emacs
+configurations as needed.
 
 ** Helps you learn Emacs Lisp
 
-Instead of providing a higher-level configuration system out of the box like other Emacs configurations, we follow standard Emacs Lisp patterns so that you can learn by reading the configuration.
+Instead of providing a higher-level configuration system out of the
+box like other Emacs configurations, we follow standard Emacs Lisp
+patterns so that you can learn by reading the configuration.
 
 * Why use it?
 
-Why choose this configuration over Doom Emacs, Spacemacs, Prelude, or others?
+Why choose this configuration over Doom Emacs, Spacemacs, Prelude, or
+others?
 
-The goal of this configuration is to make it easier to write your own Emacs configuration while using pre-made configuration parts maintained by the community.  Instead of using a monolithic, all-encompassing approach, we strive to ensure that all parts of this configuration are optional or interchangeable.
+The goal of this configuration is to make it easier to write your own
+Emacs configuration while using pre-made configuration parts
+maintained by the community.  Instead of using a monolithic,
+all-encompassing approach, we strive to ensure that all parts of this
+configuration are optional or interchangeable.
 
-You should even be able to use the configuration modules we provide with your own =init.el= file without using this base configuration repo!
+You should even be able to use the configuration modules we provide
+with your own =init.el= file without using this base configuration
+repo!
 
 * Modules
 
-Here is a list of the built-in modules that you may load.  Follow the links to each to get more information about how they can be configured!
+Here is a list of the built-in modules that you may load.  Follow the
+links to each to get more information about how they can be
+configured!
 
 - [[modules/rational-ui.el][rational-defaults]]: Sensible default settings for Emacs
-- [[modules/rational-ui.el][rational-ui]]: Extra UI configuration for a better experience (mode line, etc)
-- [[modules/rational-completion.el][rational-completion]]: A better selection framework configuration based on Vertico
+- [[modules/rational-ui.el][rational-ui]]: Extra UI configuration for a better experience (mode
+  line, etc)
+- [[modules/rational-completion.el][rational-completion]]: A better selection framework configuration
+  based on Vertico
 - [[modules/rational-evil.el][rational-evil]]: An evil-mode configuration
 - [[modules/rational-windows.el][rational-windows]]: Window management configuration
-- [[modules/rational-use-package.el][rational-use-package]]: Configuration for use-package if you prefer it over straight.el
+- [[modules/rational-use-package.el][rational-use-package]]: Configuration for use-package if you prefer it
+  over straight.el
 
 Modules that we will be adding in the future:
 
 - rational-desktop: A desktop environment centered around EXWM
 - rational-present: Tools for giving presentations
 - rational-screencast: Tools for doing screencasts
-- rational-workspace: An improved workspace experience based on =tab-bar-mode=
+- rational-workspace: An improved workspace experience based on
+  =tab-bar-mode=
 - rational-shell: A starter configuration for =eshell= and =vterm=
 
 * Customization
 
-To add your own customization to this configuration, create a configuraton file in one of the following places:
+To add your own customization to this configuration, create a
+configuraton file in one of the following places:
 
 - =~/.rational-emacs/config.el=
 - =~/.config/rational-emacs/config.el=
 
-In your configuration you can set any Emacs configuration variable, face attributes, themes, etc as you normally would.
+In your configuration you can set any Emacs configuration variable,
+face attributes, themes, etc as you normally would.
 
 For example:
 
@@ -115,7 +156,9 @@ For example:
 
 * Using it with Chemacs2
 
-If you have the Chemacs2 configuration cloned to =~/.emacs.d= or =~/.config/emacs=, you can clone =rational-emacs= anywhere you like and add an entry to it in your =~/.emacs-profiles.el= file:
+If you have the Chemacs2 configuration cloned to =~/.emacs.d= or
+=~/.config/emacs=, you can clone =rational-emacs= anywhere you like
+and add an entry to it in your =~/.emacs-profiles.el= file:
 
 #+begin_src emacs-lisp
 
@@ -127,4 +170,5 @@ Then launch it with =emacs --with-profile rational=!
 
 * License
 
-This code is licensed under the MIT License.  Why?  So you can copy the code from this configuration!
+This code is licensed under the MIT License.  Why?  So you can copy
+the code from this configuration!

--- a/early-init.el
+++ b/early-init.el
@@ -46,5 +46,4 @@
 
 ;; Load the early config file if it exists
 (let ((early-config-path (expand-file-name "early-config.el" rational-config-path)))
-  (when (file-exists-p early-config-path)
-    (load early-config-path nil 'nomessage)))
+  (load early-config-path 'noerror 'nomessage))

--- a/init.el
+++ b/init.el
@@ -3,10 +3,8 @@
 ;; Profile emacs startup
 (add-hook 'emacs-startup-hook
           (lambda ()
-            (message "Rational Emacs loaded in %s."
-                     (format "%.2f seconds"
-                             (float-time
-                              (time-subtract after-init-time before-init-time))))))
+            (message "Rational Emacs loaded in %s." (emacs-init-time))))
+
 ;; Save customizing settings in a separate file
 (setq custom-file (locate-user-emacs-file "emacs-custom.el"))
 (load custom-file 'noerror)

--- a/init.el
+++ b/init.el
@@ -7,6 +7,9 @@
                      (format "%.2f seconds"
                              (float-time
                               (time-subtract after-init-time before-init-time))))))
+;; Save customizing settings in a separate file
+(setq custom-file (locate-user-emacs-file "emacs-custom.el"))
+(load custom-file 'noerror)
 
 ;; Add the modules folder to the load path
 (add-to-list 'load-path (expand-file-name "modules/" user-emacs-directory))

--- a/init.el
+++ b/init.el
@@ -42,8 +42,7 @@ straight.el or Guix depending on the value of
   "The user's configuration file.")
 
 ;; Load the user configuration file if it exists
-(when (file-exists-p rational-config-file)
-  (load rational-config-file nil 'nomessage))
+(load rational-config-file 'noerror 'nomessage)
 
 ;; Make GC pauses faster by decreasing the threshold.
 (setq gc-cons-threshold (* 2 1000 1000))

--- a/modules/rational-use-package.el
+++ b/modules/rational-use-package.el
@@ -4,8 +4,15 @@
 
 (require 'package)
 
-(setq package-archives '(("melpa" . "https://melpa.org/packages/")
-                         ("elpa" . "https://elpa.gnu.org/packages/")))
+;; gnu and nongnu is needed for packages like Org-mode
+(setq package-archives
+      '(("gnu" . "https://elpa.gnu.org/packages/")))
+(add-to-list package-archives
+	     '("nongnu" . "https://elpa.nongnu.org/nongnu") 'append)
+(add-to-list package-archives
+	     '("melpa" . "https://melpa.org/packages/") 'append)
+(add-to-list package-archives
+	     '("elpa" . "https://elpa.gnu.org/packages/") 'append)
 
 (package-initialize)
 (unless package-archive-contents


### PR DESCRIPTION
This is several different small pulls that could be useful.

* Max line length are usually set to about under 80 characters.
* Org-mode want to use GNU elpa repositories, so they should probably be added first.
* There are already a function for calculation the execution time to init Emacs.
* Customizing settings moved to a file of it's own and load those when starting (maybe in early-init.el).
* Added non nil to NOERROR argument of load to not bail out if the file doesn't exist (or error loading), then no need for check if file exists.
* Just let git ignore standard Emacs temp files.

But as I am new to using GitHub, I guess I have to figure this out how to do this in Emacs magit.