### PR TITLE
Better support for long lines

### DIFF
--- a/modules/rational-defaults.el
+++ b/modules/rational-defaults.el
@@ -22,6 +22,11 @@
 (setq scroll-margin 0)
 (setq scroll-preserve-screen-position t)
 
+;; Better support for files with long lines
+(setq-default bidi-paragraph-direction 'left-to-right)
+(setq-default bidi-inhibit-bpa t)
+(global-so-long-mode 1)
+
 ;; Make shebang (#!) file executable when saved
 (add-hook 'after-save-hook 'executable-make-buffer-file-executable-if-script-p)
 


### PR DESCRIPTION
The bidi settings since some people do need bidirectional support but that's pretty rare. Either way the global-so-long-mode is a must. Basically it turns off features that would have stopped Emacs in it's tracks whenever long lines are detected.