### PR TITLE
(fix:rational-defaults) Activate recentf-mode after init

### DIFF
--- a/modules/rational-defaults.el
+++ b/modules/rational-defaults.el
@@ -13,7 +13,7 @@
 (fset 'yes-or-no-p 'y-or-n-p)
 
 ;; Turn on recentf mode
-(recentf-mode 1)
+(add-hook 'after-init-hook (lambda () (recentf-mode 1)))
 (setq recentf-save-file (expand-file-name "recentf" rational-config-var-directory))
 
 ;; Do not saves duplicates in kill-ring

--- a/modules/rational-defaults.el
+++ b/modules/rational-defaults.el
@@ -13,7 +13,7 @@
 (fset 'yes-or-no-p 'y-or-n-p)
 
 ;; Turn on recentf mode
-(add-hook 'after-init-hook (lambda () (recentf-mode 1)))
+(add-hook 'after-init-hook #'recentf-mode)
 (setq recentf-save-file (expand-file-name "recentf" rational-config-var-directory))
 
 ;; Do not saves duplicates in kill-ring


### PR DESCRIPTION
`recentf-mode` reads `recentf-save-file` when being activated, so loading it immediately makes it impossible for the user to customize the path. Also because my previous PR defines the variable after loading the mode, `recentf` does not work unless the user execute `recentf-load-list`. The reason I missed this while doing my PR is that I had a call to `recentf-load-list` in my custom `recentf` module 🤦🏻 

Another approach would be to activate `recentf` immediately (as we are doing right now) and delay a call to `recentf-load-list` but this adds a line of code with no strong justification IMO. It would look like this:

```elisp
(recentf-mode 1)
(setq recentf-save-file (expand-file-name "recentf" rational-config-var-directory))
(add-hook 'after-init-hook (lambda () (recentf-load-list)))
```