### PR TITLE
Add headers to modules

### DIFF
--- a/modules/rational-completion.el
+++ b/modules/rational-completion.el
@@ -1,5 +1,19 @@
 ;;; rational-completion.el -*- lexical-binding: t; -*-
 
+;; Copyright (C) 2022
+;; SPDX-License-Identifier: MIT
+
+;; Author: System Crafters Community
+
+;; Commentary
+
+;; Setup completion packages. Completion in this sense is more like
+;; narrowing, allowing the user to find matches based on minimal
+;; inputs and "complete" the commands, variables, etc from the
+;; narrowed list of possible choices.
+
+;;; Code:
+
 (straight-use-package 'vertico)
 (straight-use-package 'consult)
 (straight-use-package 'orderless)
@@ -63,3 +77,4 @@ folder, otherwise delete a word"
 (setq prefix-help-command #'embark-prefix-help-command)
 
 (provide 'rational-completion)
+;;; rational-completion.el ends here

--- a/modules/rational-defaults.el
+++ b/modules/rational-defaults.el
@@ -1,5 +1,16 @@
 ;;; rational-defaults.el -*- lexical-binding: t; -*-
 
+;; Copyright (C) 2022
+;; SPDX-License-Identifier: MIT
+
+;; Author: System Crafters Community
+
+;; Commentary
+
+;; General sane defaults
+
+;;; Code:
+
 ;; Revert Dired and other buffers
 (customize-set-variable 'global-auto-revert-non-file-buffers t)
 
@@ -35,3 +46,4 @@
 (add-hook 'after-save-hook 'executable-make-buffer-file-executable-if-script-p)
 
 (provide 'rational-defaults)
+;;; rational-defaults.el ends here

--- a/modules/rational-editing.el
+++ b/modules/rational-editing.el
@@ -1,5 +1,16 @@
 ;;; rational-editing.el -*- lexical-binding: t; -*-
 
+;; Copyright (C) 2022
+;; SPDX-License-Identifier: MIT
+
+;; Author: System Crafters Community
+
+;; Commentary
+
+;; Editing text configuration.
+
+;;; Code:
+
 (straight-use-package 'ws-butler)
 (straight-use-package 'evil-nerd-commenter)
 
@@ -15,3 +26,4 @@
 (show-paren-mode 1)    ; turn on paren match highlighting
 
 (provide 'rational-editing)
+;;; rational-editing.el ends here

--- a/modules/rational-evil.el
+++ b/modules/rational-evil.el
@@ -1,5 +1,16 @@
 ;;; rational-evil.el -*- lexical-binding: t; -*-
 
+;; Copyright (C) 2022
+;; SPDX-License-Identifier: MIT
+
+;; Author: System Crafters Community
+
+;; Commentary
+
+;; Evil mode configuration, for those who prefer `vi' keybindings.
+
+;;; Code:
+
 ;; Define configuration variables
 (defcustom rational-evil-discourage-arrow-keys nil
   "When t, prevent the use of arrow keys in normal state to
@@ -61,3 +72,4 @@ encourage the use of Vim-style movement keys (hjkl).")
   (add-to-list 'evil-emacs-state-modes mode))
 
 (provide 'rational-evil)
+;;; rational-evil.el ends here

--- a/modules/rational-screencast.el
+++ b/modules/rational-screencast.el
@@ -1,5 +1,16 @@
 ;;; rational-screencast.el -*- lexical-binding: t; -*-
 
+;; Copyright (C) 2022
+;; SPDX-License-Identifier: MIT
+
+;; Author: System Crafters Community
+
+;; Commentary
+
+;; Screencast configuration
+
+;;; Code:
+
 (straight-use-package 'keycast)
 
 (customize-set-variable 'keycast-remove-tail-elements nil)
@@ -7,3 +18,4 @@
 (keycast-mode)
 
 (provide 'rational-screencast)
+;;; rational-screencast.el ends here

--- a/modules/rational-ui.el
+++ b/modules/rational-ui.el
@@ -1,5 +1,17 @@
 ;;; rational-ui.el -*- lexical-binding: t; -*-
 
+;; Copyright (C) 2022
+;; SPDX-License-Identifier: MIT
+
+;; Author: System Crafters Community
+
+;; Commentary
+
+;; User interface customizations. Examples are the modeline and how
+;; help buffers are displayed.
+
+;;; Code:
+
 (straight-use-package 'all-the-icons)
 (straight-use-package 'doom-modeline)
 (straight-use-package 'doom-themes)
@@ -73,3 +85,4 @@ Use a plist with the same key names as accepted by `set-face-attribute'.")
   (advice-add command :after #'pulse-line))
 
 (provide 'rational-ui)
+;;; rational-ui.el ends here

--- a/modules/rational-use-package.el
+++ b/modules/rational-use-package.el
@@ -1,5 +1,17 @@
 ;;; rational-use-package.el -*- lexical-binding: t; -*-
 
+;; Copyright (C) 2022
+;; SPDX-License-Identifier: MIT
+
+;; Author: System Crafters Community
+
+;; Commentary
+
+;; Built-in `package.el' with `use-package' configuration, including
+;; elpas to search.
+
+;;; Code:
+
 (straight-use-package 'use-package)
 
 (require 'package)
@@ -18,3 +30,4 @@
   (package-refresh-contents))
 
 (provide 'rational-use-package)
+;;; rational-use-package.el ends here

--- a/modules/rational-windows.el
+++ b/modules/rational-windows.el
@@ -1,5 +1,16 @@
 ;;; rational-windows.el -*- lexical-binding: t; -*-
 
+;; Copyright (C) 2022
+;; SPDX-License-Identifier: MIT
+
+;; Author: System Crafters Community
+
+;; Commentary
+
+;; Emacs windows configuration.
+
+;;; Code:
+
 (defcustom rational-windows-evil-style nil
   "When t, window movement bindings will be evil-style.")
 
@@ -19,3 +30,4 @@
 (global-set-key (kbd rational-windows-prefix-key) 'rational-windows-key-map)
 
 (provide 'rational-windows)
+;;; rational-windows.el ends here


### PR DESCRIPTION
This will make them match usage of the skeleton when additional
modules are created, so they all look consistent. Some minor attempt
at words in the "Commentary" section was made, however, more could be
done to provide better documentation for each module.