### PR TITLE
Add support for customizing modes to display line numbers. 

### DIFF
--- a/modules/rational-ui.el
+++ b/modules/rational-ui.el
@@ -64,7 +64,8 @@ Use a plist with the same key names as accepted by `set-face-attribute'.")
 (defcustom rational-ui-line-numbers-disabled-modes
   '(org-mode)
   "Modes which should not display line numbers.
-Modes deriverd from the modes defined in `rational-ui-line-number-enabled-modes', but should not display line numbers."
+Modes deriverd from the modes defined in
+`rational-ui-line-number-enabled-modes', but should not display line numbers."
   :type 'list
   :group 'rational)
 

--- a/modules/rational-ui.el
+++ b/modules/rational-ui.el
@@ -86,11 +86,9 @@ Used as hook for modes which should not display line numebrs."
   (if rational-ui-display-line-numbers
       (progn
         (dolist (mode rational-ui-line-numbers-enabled-modes)
-          (message "enabling line numbers for %s" mode)
           (add-hook (intern (format "%s-hook" mode))
                     #'rational-ui--enable-line-numbers-mode))
         (dolist (mode rational-ui-line-numbers-disabled-modes)
-          (message "disabling line numbers for %s" mode)
           (add-hook (intern (format "%s-hook" mode))
                     #'rational-ui--disable-line-numbers-mode))
         (setq-default

--- a/modules/rational-ui.el
+++ b/modules/rational-ui.el
@@ -64,7 +64,7 @@ Use a plist with the same key names as accepted by `set-face-attribute'.")
 (defcustom rational-ui-line-numbers-disabled-modes
   '(org-mode)
   "Modes which should not display line numbers.
-Modes deriverd from the modes defined in
+Modes derived from the modes defined in
 `rational-ui-line-number-enabled-modes', but should not display line numbers."
   :type 'list
   :group 'rational)

--- a/modules/rational-ui.el
+++ b/modules/rational-ui.el
@@ -55,18 +55,62 @@ Use a plist with the same key names as accepted by `set-face-attribute'.")
 
 ;;;; Line Numbers
 
+(defcustom rational-ui-line-numbers-enabled-modes
+  '(conf-mode prog-mode text-mode)
+  "Modes which should display line numbers."
+  :type 'list
+  :group 'rational)
+
+(defcustom rational-ui-line-numbers-disabled-modes
+  '(org-mode)
+  "Modes which should not display line numbers.
+Modes deriverd from the modes defined in `rational-ui-line-number-enabled-modes', but should not display line numbers."
+  :type 'list
+  :group 'rational)
+
+(defun rational-ui--enable-line-numbers-mode ()
+  "Turn on line numbers mode.
+
+Used as hook for modes which should display line numbers."
+  (display-line-numbers-mode 1))
+
+(defun rational-ui--disable-line-numbers-mode ()
+  "Turn off line numbers mode.
+
+Used as hook for modes which should not display line numebrs."
+  (display-line-numbers-mode -1))
+
+(defun rational-ui--update-line-numbers-display ()
+  "Update configuration for line numbers display."
+  (if rational-ui-display-line-numbers
+      (progn
+        (dolist (mode rational-ui-line-numbers-enabled-modes)
+          (message "enabling line numbers for %s" mode)
+          (add-hook (intern (format "%s-hook" mode))
+                    #'rational-ui--enable-line-numbers-mode))
+        (dolist (mode rational-ui-line-numbers-disabled-modes)
+          (message "disabling line numbers for %s" mode)
+          (add-hook (intern (format "%s-hook" mode))
+                    #'rational-ui--disable-line-numbers-mode))
+        (setq-default
+         display-line-numbers-grow-only t
+         display-line-numbers-type t
+         display-line-numbers-width 2))
+     (progn
+       (dolist (mode rational-ui-line-numbers-enabled-modes)
+         (remove-hook (intern (format "%s-hook" mode))
+                      #'rational-ui--enable-line-numbers-mode))
+       (dolist (mode rational-ui-line-numbers-disabled-modes)
+         (remove-hook (intern (format "%s-hook" mode))
+                      #'rational-ui--disable-line-numbers-mode)))))
+
 (defcustom rational-ui-display-line-numbers nil
   "Whether line numbers should be enabled."
-  :type 'boolean)
-
-(when rational-ui-display-line-numbers
-  (add-hook 'conf-mode-hook #'display-line-numbers-mode)
-  (add-hook 'prog-mode-hook #'display-line-numbers-mode)
-  (add-hook 'text-mode-hook #'display-line-numbers-mode)
-  (setq-default
-   display-line-numbers-grow-only t
-   display-line-numbers-type t
-   display-line-numbers-width 2))
+  :type 'boolean
+  :group 'rational
+  :set (lambda (sym val)
+         (set-default sym val)
+         (rational-ui--update-line-numbers-display)))
 
 ;;;; Elisp-Demos
 

--- a/modules/rational-ui.el
+++ b/modules/rational-ui.el
@@ -56,7 +56,7 @@ Use a plist with the same key names as accepted by `set-face-attribute'.")
 ;;;; Line Numbers
 
 (defcustom rational-ui-line-numbers-enabled-modes
-  '(conf-mode prog-mode text-mode)
+  '(conf-mode prog-mode)
   "Modes which should display line numbers."
   :type 'list
   :group 'rational)


### PR DESCRIPTION
Adds two additional custom variables and support for updating
the display of line numbers based on a change to the
`rational-ui-display-line-numbers` variable.

Added the 'rational' group to each of the custom variables.

Supporting `:set` on the `rational-ui-display-line-numbers`  allows someone to specify:

    (custom-set-variables '(rational-ui-display-line-numbers t))

after `(require 'rational-ui)` and still have the intended effect.