### PR TITLE
Use alias instead of fset

### DIFF
--- a/modules/rational-defaults.el
+++ b/modules/rational-defaults.el
@@ -23,7 +23,12 @@
 ;; Use "y" and "n" to confirm/negate prompt instead of "yes" and "no"
 ;; Using `advice' here to make it easy to reverse in custom
 ;; configurations with `(advice-remove 'yes-or-no-p #'y-or-n-p)'
-(advice-add 'yes-or-no-p :override #'y-or-n-p)
+;;
+;; N.B. Emacs 28 has a variable for using short answers, which should
+;; be preferred if using that version or higher.
+(if (boundp 'use-short-answers)
+    (setq use-short-answers t)
+  (advice-add 'yes-or-no-p :override #'y-or-n-p))
 
 ;; Turn on recentf mode
 (add-hook 'after-init-hook #'recentf-mode)

--- a/modules/rational-defaults.el
+++ b/modules/rational-defaults.el
@@ -21,7 +21,9 @@
 (setq-default indent-tabs-mode nil)
 
 ;; Use "y" and "n" to confirm/negate prompt instead of "yes" and "no"
-(fset 'yes-or-no-p 'y-or-n-p)
+;; Using `advice' here to make it easy to reverse in custom
+;; configurations with `(advice-remove 'yes-or-no-p #'y-or-n-p)'
+(advice-add 'yes-or-no-p :override #'y-or-n-p)
 
 ;; Turn on recentf mode
 (add-hook 'after-init-hook #'recentf-mode)


### PR DESCRIPTION
fset is really difficult to revert in the event the user wishes to use longer answers (ie "yes"/"no") for confirm/negate prompts. This patch uses advice and includes logic from #47 making use of `use-short-answers` when it is available. 