### PR TITLE
Emacs init time and load with`noerror' 

### DIFF
--- a/early-init.el
+++ b/early-init.el
@@ -67,5 +67,4 @@
 
 ;; Load the early config file if it exists
 (let ((early-config-path (expand-file-name "early-config.el" rational-config-path)))
-  (when (file-exists-p early-config-path)
-    (load early-config-path nil 'nomessage)))
+  (load early-config-path 'noerror 'nomessage))

--- a/init.el
+++ b/init.el
@@ -32,7 +32,7 @@
         'silent 'inhibit-cookies)
       (goto-char (point-max))
       (eval-print-last-sexp)))
-  (load bootstrap-file nil 'nomessage))
+  (load bootstrap-file 'noerror 'nomessage))
 
 (defun rational-ensure-package (package &optional args)
   "Ensure that PACKAGE is installed on the system, either via

--- a/init.el
+++ b/init.el
@@ -1,5 +1,10 @@
 ;;; init.el -*- lexical-binding: t; -*-
 
+;; Don't save customize variables in `init.el', save them in
+;; "emacs-custom.el" instead. Don't bail out if file doesn't exist.
+(setq custom-file (locate-user-emacs-file "emacs-custom.el"))
+(load custom-file 'noerror)
+
 ;; Profile emacs startup
 (add-hook 'emacs-startup-hook
           (lambda ()

--- a/init.el
+++ b/init.el
@@ -58,8 +58,7 @@ straight.el or Guix depending on the value of
 (mkdir rational-config-var-directory t)
 
 ;; Load the user configuration file if it exists
-(when (file-exists-p rational-config-file)
-  (load rational-config-file nil 'nomessage))
+(load rational-config-file 'noerror 'nomessage)
 
 ;; when writing rational-modules, insert header from skeleton
 (auto-insert-mode)

--- a/modules/rational-updates.el
+++ b/modules/rational-updates.el
@@ -9,41 +9,79 @@
 
 ;;; Code:
 
+(defun rational-updates--call-git (&rest args)
+  (let ((default-directory user-emacs-directory))
+    (with-temp-buffer
+      (if (apply #'vc-git--out-ok args)
+          (buffer-string)
+        nil))))
+
 (defun rational-updates--get-new-commit-count ()
-  (string-to-number (shell-command-to-string "git rev-list --count master..origin/master")))
+  (string-to-number (rational-updates--call-git "rev-list" "--count" "master..origin/master")))
+
+(defun rational-updates--notify-of-updates ()
+  (if (> (rational-updates--get-new-commit-count) 0)
+      (message "Rational Emacs updates are available!")
+    (message "Rational Emacs is up to date!")))
 
 (defun rational-updates--poll-git-fetch-status (process)
   (if (eql (process-status process) 'exit)
       (when (eql (process-exit-status process) 0)
-          (if (> (rational-updates--get-new-commit-count) 0)
-              (message "Rational Emacs updates are available!")
-            (message "Rational Emacs is up to date!")))
+          )
     (run-at-time 1 nil #'rational-updates--poll-git-fetch-status process)))
 
+(defun rational-updates--find-init-el ()
+  (find-file-noselect (expand-file-name "init.el" user-emacs-directory)))
+
 (defun rational-updates-check-for-latest ()
+  "Fetches the latest Rational Emacs commits from GitHub and
+notifies you if there are any updates."
   (interactive)
-  (let ((git-process (start-process-shell-command "rational-git-fetch" nil "git fetch origin")))
-    (run-at-time 1 nil #'rational-updates--poll-git-fetch-status git-process)))
+  (message "Checking for Rational Emacs updates...")
+  (when (rational-updates--call-git #' "fetch" "origin")
+    (rational-updates--notify-of-updates)))
 
 (defun rational-updates-show-latest ()
+  "Shows a buffer containing a log of the latest commits to
+Rational Emacs."
   (interactive)
   (message "Fetching latest commit log for Rational Emacs...")
   (with-current-buffer (find-file-noselect (expand-file-name "init.el" user-emacs-directory))
     (vc-log-incoming)))
 
 (defun rational-updates--pull-commits ()
-  (interactive)
   (message "Pulling latest commits to Rational Emacs...")
   (with-current-buffer (find-file-noselect (expand-file-name "init.el" user-emacs-directory))
     (vc-pull)))
 
 (defun rational-updates-pull-latest ()
+  "Pulls the latest updates to Rational Emacs into the local
+configuration repository."
   (interactive)
   (let ((prompt-answer (read-string "This will update your Rational Emacs configuration, are you sure?  [yes/no/Log]: ")))
     (pcase (downcase prompt-answer)
       ("yes" (rational-updates--pull-commits))
       ("no" (message "You can always check the latest commits by running M-x rational-updates-show-latest."))
       ("log" (rational-updates-show-latest)))))
+
+(defvar rational-updates-fetch-interval "24 hours"
+  "The interval at which `rational-updates-mode' will check for updates.")
+
+(defun rational-updates--do-automatic-fetch ()
+  (when rational-updates-mode
+    (rational-updates-check-for-latest)
+    (rational-updates--schedule-fetch)))
+
+(defun rational-updates--schedule-fetch ()
+  (run-at-time rational-updates-fetch-interval nil #'rational-updates--do-automatic-fetch))
+
+(define-minor-mode rational-updates-mode
+  "Provides an automatic update checking feature for Rational
+Emacs.  When enabled, it will automatically check for updates at
+the specified `rational-updates-fetch-interval'."
+  :global t
+  (when rational-updates-mode
+    (rational-updates--schedule-fetch)))
 
 (provide 'rational-updates)
 ;;; rational-updates.el ends here

--- a/modules/rational-updates.el
+++ b/modules/rational-updates.el
@@ -64,8 +64,9 @@ configuration repository."
       ("no" (message "You can always check the latest commits by running M-x rational-updates-show-latest."))
       ("log" (rational-updates-show-latest)))))
 
-(defvar rational-updates-fetch-interval "24 hours"
-  "The interval at which `rational-updates-mode' will check for updates.")
+(defcustom rational-updates-fetch-interval "24 hours"
+  "The interval at which `rational-updates-mode' will check for updates."
+  :group 'rational)
 
 (defun rational-updates--do-automatic-fetch ()
   (when rational-updates-mode
@@ -80,6 +81,7 @@ configuration repository."
 Emacs.  When enabled, it will automatically check for updates at
 the specified `rational-updates-fetch-interval'."
   :global t
+  :group 'rational
   (when rational-updates-mode
     (rational-updates--schedule-fetch)))
 


### PR DESCRIPTION
Store and load custom variables in "emacs-custom.el" instead of in "init.el".

Make load ignore errors, like non existing files with `noerror'.