### PR TITLE
updates: Make rational-updates-pull-latest usable within configs

### DIFF
--- a/modules/rational-updates.el
+++ b/modules/rational-updates.el
@@ -54,15 +54,27 @@ Rational Emacs."
   (with-current-buffer (find-file-noselect (expand-file-name "init.el" user-emacs-directory))
     (vc-pull)))
 
-(defun rational-updates-pull-latest ()
-  "Pulls the latest updates to Rational Emacs into the local
-configuration repository."
-  (interactive)
-  (let ((prompt-answer (read-string "This will update your Rational Emacs configuration, are you sure?  [yes/no/Log]: ")))
-    (pcase (downcase prompt-answer)
-      ("yes" (rational-updates--pull-commits))
-      ("no" (message "You can always check the latest commits by running M-x rational-updates-show-latest."))
-      ("log" (rational-updates-show-latest)))))
+(defun rational-updates-pull-latest (do-pull)
+  "Pull the latest Rational Emacs version into the local repository.
+
+If DO-PULL is nil then only the latest updates will be shown,
+otherwise the local repository will get updated to the GitHub
+version.
+
+Interactively, the default if you just type RET is to show recent
+changes as if you called `rational-updates-show-latest'.
+
+With a `\\[universal-argument]' prefix immediately pull changes
+and don't prompt for confirmation."
+  (interactive
+   (list
+    (or current-prefix-arg
+        (pcase (completing-read "Rational Update Action: " '("Show Log" "Update") nil t nil nil "Show Log")
+          ("Show Log" nil)
+          ("Update" t)))))
+  (if do-pull
+      (rational-updates--pull-commits)
+    (rational-updates-show-latest)))
 
 (defcustom rational-updates-fetch-interval "24 hours"
   "The interval at which `rational-updates-mode' will check for updates."


### PR DESCRIPTION
## Summary

This PR more or less rewrites `rational-updates-pull-latest` to enable usage within user configurations. 

## Details
Here are the  changes in detail.

### New argument `DO-PULL`
The previous variant needed user input to pull. However, there might be some users that want to live on the... interesting side of life and automatically update their rational modules every Sunday (or something similar).

The argument `DO-PULL` can be set from within configurations and thus entirely skip the (interactive) section:

```lisp
(rational-updates-pull-latest t)
```

This might also be helpful if the user has similar functionality for their own configuration, e.g.

```lisp
(my/update-my-configuration 'yes-please)
(rational-updates-pull-latest t)
```

### User interaction completely in `(interactive)`
Previously, `read-string` was called in every call of the function. Unfortunately, this conflicts with the other goal. While we could use an `&optional do-pull`, this still mixes a user interaction with functionality.

So instead we create the argument list from within `(interactive)` itself. For more information, see `(elisp) Using interactive`. Similarly, we skip the prompt if there's a non-nil prefix argument. The user (probably) knows what they want if they call

    C-u M-x rational-updates-pull-latest

### Using completing-read instead of read-string
The `completing-read` call ensures that we *only* get answers from the given set (via `REQUIRE-MATCH`) and also always start  with `"Show Log"` (via `DEF`). The latter is especially important, since modes like `savehist-mode` or certain completion styles might accidentally choose `"Update"` instead.

## Concerns/Breaking changes
This PR does not break existing features, but slightly changes the expected user input from `yes`/`Log` to a completing prompt. Furthermore, it encourages users to use `(rational-updates-pull-latest t)` if they want to, instead of the private `(rational-updates--pull-commits)`.

However, it introduces a new public API, which might be unwelcome.

### Meta concerns
This PR consists of a single commit with a rather large\* commit message to explain the changes. The current commit can be split into the aforementioned three (more or less atomic) parts. Feel free to ping me if you want the commit split.

<sub>* large as in changing multiple things at once, instead of just a single thing; it's only 15 lines of SLOC changes</sub>