### PR TITLE
Starting configuration for project management

### DIFF
--- a/init.el
+++ b/init.el
@@ -45,7 +45,7 @@ straight.el or Guix depending on the value of
   "The user's configuration file.")
 
 ;; Defines the user configuration var and etc folders
-;; and ensure they exists.
+;; and ensure they exist.
 (defvar rational-config-etc-directory (expand-file-name "etc/" rational-config-path)
   "The user's configuration etc/ folder.")
 (defvar rational-config-var-directory (expand-file-name "var/" rational-config-path)
@@ -58,7 +58,7 @@ straight.el or Guix depending on the value of
 (when (file-exists-p rational-config-file)
   (load rational-config-file nil 'nomessage))
 
-;; when writing rational-modules, insert header from skeleton
+;; When writing rational-modules, insert header from skeleton
 (auto-insert-mode)
 (with-eval-after-load "autoinsert"
   (define-auto-insert

--- a/modules/rational-project.el
+++ b/modules/rational-project.el
@@ -1,0 +1,19 @@
+;;;; rational-project.el --- Starting configuration for project management  -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2022
+;; SPDX-License-Identifier: MIT
+
+;; Author: System Crafters Community
+
+;;; Commentary
+
+;;
+
+;;; Code:
+
+(let ((user-projects (expand-file-name "projects" rational-config-path)))
+(when (file-exists-p user-projects)
+  (setq project-list-file user-projects)))
+
+(provide 'rational-project)
+;;; rational-project.el ends here

--- a/modules/rational-project.el
+++ b/modules/rational-project.el
@@ -12,8 +12,8 @@
 ;;; Code:
 
 (let ((user-projects (expand-file-name "projects" rational-config-path)))
-(when (file-exists-p user-projects)
-  (setq project-list-file user-projects)))
+  (when (file-exists-p user-projects)
+    (setq project-list-file user-projects)))
 
 (provide 'rational-project)
 ;;; rational-project.el ends here

--- a/modules/rational-project.el
+++ b/modules/rational-project.el
@@ -7,13 +7,11 @@
 
 ;;; Commentary
 
-;;
+;; Provides default settings for project management with project.el
 
 ;;; Code:
 
-(let ((user-projects (expand-file-name "projects" rational-config-path)))
-  (when (file-exists-p user-projects)
-    (setq project-list-file user-projects)))
+(customize-set-variable 'project-list-file (expand-file-name "projects" rational-config-var-directory))
 
 (provide 'rational-project)
 ;;; rational-project.el ends here


### PR DESCRIPTION
I have noticed that there is nothing to point the `project-list-file` variable to a file in the `rational-config-path`, because the default is to lookup to `user-emacs-directory`, which I belive is not quite right, since that file is a user's customization.

Maybe some other configurations could be added here.