### PR TITLE
Fix the default skeleton for modules

### DIFF
--- a/init.el
+++ b/init.el
@@ -74,7 +74,7 @@ straight.el or Guix depending on the value of
 
 ;; Author: System Crafters Community
 
-;; Commentary
+;;; Commentary:
 
 ;; " _ "
 


### PR DESCRIPTION
The default skeleton is generating

``` lisp
;; Commentary
```

instead of

``` lisp
;;; Commentary:
```