### PR TITLE
Update rational-ui-default-font with :set, fix setting default

### DIFF
--- a/README.org
+++ b/README.org
@@ -183,10 +183,9 @@ filesystem, it is created. However, just the path is created, the files
   (require 'rational-windows)
 
   ;; Set further font and theme customizations
-  (set-face-attribute 'default nil
-                    :font "JetBrains Mono"
-                    :weight 'light
-                    :height 185)
+  (custom-set-variables
+   '(rational-ui-default-font
+     '(:font "JetBrains Mono" :weight 'light :height 185)))
 
   (load-theme 'doom-snazzy t)
 

--- a/example-config.el
+++ b/example-config.el
@@ -21,10 +21,9 @@
 (require 'rational-windows)
 
 ;; Set further font and theme customizations
-(set-face-attribute 'default nil
-                  :font "JetBrains Mono"
-                  :weight 'light
-                  :height 185)
+(custom-set-variables
+   '(rational-ui-default-font
+     '(:font "JetBrains Mono" :weight 'light :height 185)))
 
 (load-theme 'doom-snazzy t)
 

--- a/modules/rational-ui.el
+++ b/modules/rational-ui.el
@@ -20,12 +20,28 @@
 
 ;;;; Font
 
+(defun rational-ui--set-default-font (spec)
+  "Set the default font based on SPEC.
+
+SPEC is expected to be a plist with the same key names
+as accepted by `set-face-attribute'."
+  (when spec
+    (apply 'set-face-attribute 'default nil spec)))
+
+
 (defcustom rational-ui-default-font nil
   "The configuration of the `default' face.
-Use a plist with the same key names as accepted by `set-face-attribute'.")
-
-(when rational-ui-default-font
-  (apply 'set-face-attribute 'default nil (cons :font rational-ui-default-font)))
+Use a plist with the same key names as accepted by `set-face-attribute'."
+  :group 'rational
+  :type '(plist :key-type: symbol)
+  :tag "Default font"
+  :set (lambda (sym val)
+         (let ((prev-val (if (boundp 'rational-ui-default-font)
+                             rational-ui-default-font
+                         nil)))
+         (set-default sym val)
+         (when (and val (not (eq val prev-val)))
+           (rational-ui--set-default-font val)))))
 
 ;;;; Mode-Line
 


### PR DESCRIPTION
`rational-ui-default-font` can now be custom set before
or after the `rational-ui` module is required.

Added function `rational-ui--set-default-font` to use
as `set` function for `rational-ui-default-font`.

Removed the `when` form which set the default font
when `rational-ui` was loaded. Value is only set now
when the custom variable is modified.

Fixes #70 