### PR TITLE
Two improvements to rational-editing.el

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,6 @@ straight/
 transient/
 eshell/
 projects
+.DS_Store
+history
+places

--- a/README.org
+++ b/README.org
@@ -114,6 +114,7 @@ information about how they can be configured!
 - [[file:modules/rational-windows.el][rational-windows]] :: Window management configuration
 - [[file:modules/rational-use-package.el][rational-use-package]] :: Configuration for =use-package= if you prefer it over
   =straight.el=
+- [[file:modules/rational-persistence.el][rational-persistence]] :: Making emacs persist some things between sessions
 
 Modules that we will be adding in the future:
 

--- a/modules/rational-editing.el
+++ b/modules/rational-editing.el
@@ -25,5 +25,11 @@
 (electric-pair-mode 1) ; auto-insert matching bracket
 (show-paren-mode 1)    ; turn on paren match highlighting
 
+;; When text is selected, overwrite it by typing
+(delete-selection-mode 1)
+
+;; easilyNavigateCamelCase
+(global-subword-mode 1)
+
 (provide 'rational-editing)
 ;;; rational-editing.el ends here

--- a/modules/rational-persistence.el
+++ b/modules/rational-persistence.el
@@ -1,0 +1,35 @@
+;;; rational-persistence.el -*- lexical-binding: t; -*-
+
+;; Copyright (C) 2022
+;; SPDX-License-Identifier: MIT
+
+;; Author: System Crafters Community
+
+;; Commentary
+
+;; Some settings to make emacs more of a continous expierience.
+
+;;; Code:
+
+;; When you visit a file, point goes to the last place it was when file was previously visited.
+(save-place-mode 1)
+
+;; Saving of history (minibuffer, kill-ring, search-ring, keyboard macros, shell commands).
+(setq savehist-save-minibuffer-history t)
+  (setq savehist-additional-variables
+        '(kill-ring
+          search-ring
+          regexp-search-ring
+          last-kbd-macro
+          kmacro-ring
+          shell-command-history))
+
+(savehist-mode)
+
+;; Restore last opened buffers after closing emacs.
+(setq desktop-restore-eager 5)
+(desktop-save-mode)
+
+(provide 'rational-persistence)
+
+;;; rational-persistence.el ends here


### PR DESCRIPTION
I think having selected text be overwritten is expected behaviour for most people.
Being able to `M-f` and `M-b` through camelCased words also seems a reasonable default.

I am quite new to contributing on GitHub (or anywhere for that matter), so if these should rather be Issues that PRs or I miss anything else here, kindly let me know. :)
