### PR TITLE
(rational-editing) Add overwrite region and subword-mode

### DIFF
--- a/modules/rational-editing.el
+++ b/modules/rational-editing.el
@@ -25,5 +25,11 @@
 (electric-pair-mode 1) ; auto-insert matching bracket
 (show-paren-mode 1)    ; turn on paren match highlighting
 
+;; When text is selected, overwrite it by typing
+(delete-selection-mode 1)
+
+;; easilyNavigateCamelCase
+(global-subword-mode 1)
+
 (provide 'rational-editing)
 ;;; rational-editing.el ends here


### PR DESCRIPTION
I think having selected text be overwritten is expected behaviour for most people.
Being able to `M-f` and `M-b` through camelCasedWords also seems a reasonable default.

I am quite new to contributing on GitHub (or anywhere for that matter), so if these should rather be Issues that PRs or I miss anything else here, kindly let me know. :)