### PR TITLE
(gitignore) Add rational-emacs/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,4 +2,5 @@ eln-cache/
 straight/
 transient/
 eshell/
+rational-emacs/
 projects


### PR DESCRIPTION
Since for chemacs users without environment variable, the rational-emacs folder is assumed in the profile, it should be ignored by git.