### PR TITLE
(rational-ui) macOS transparent titlebar

### DIFF
--- a/modules/rational-ui.el
+++ b/modules/rational-ui.el
@@ -127,5 +127,12 @@ Used as hook for modes which should not display line numebrs."
 				                     recenter-top-bottom other-window))
   (advice-add command :after #'pulse-line))
 
+
+;;;; Make the titlebar on macOS transparent
+
+(when (eq system-type 'darwin) (progn
+                                 (straight-use-package 'ns-auto-titlebar)
+                                 (ns-auto-titlebar-mode)))
+
 (provide 'rational-ui)
 ;;; rational-ui.el ends here


### PR DESCRIPTION
Check for the `system-type` and load `ns-auto-titlebar.el` to make emacs look more native on current macOS versions.

With a light theme:
<img width="692" alt="Screenshot 2022-02-21 at 22 43 41" src="https://user-images.githubusercontent.com/74431172/155030495-3b585888-031b-4859-87a0-e58f197a8fd0.png">

With a dark theme:
<img width="692" alt="Screenshot 2022-02-21 at 22 44 07" src="https://user-images.githubusercontent.com/74431172/155030508-9dd7d9eb-6e77-478f-a710-755083837e6f.png">

When theme is toggled, so is the titlebar. 