### PR TITLE
Use package.el to install use-package

### DIFF
--- a/modules/rational-use-package.el
+++ b/modules/rational-use-package.el
@@ -5,14 +5,12 @@
 
 ;; Author: System Crafters Community
 
-;; Commentary
+;;; Commentary:
 
 ;; Built-in `package.el' with `use-package' configuration, including
 ;; elpas to search.
 
 ;;; Code:
-
-(straight-use-package 'use-package)
 
 (require 'package)
 
@@ -25,9 +23,21 @@
 ;; Always add melpa to `package-archives'
 (add-to-list 'package-archives (cons "melpa" "https://melpa.org/packages/"))
 
-(package-initialize)
+;; prefer gnu and nongnu elpas over melpa
+(customize-set-variable 'package-archive-priorities
+                        '(("gnu"    . 99)
+                          ("nongnu" . 80)
+                          ("melpa"  . 0)))
+
+;; don't automatically activate all the installed packages, allow
+;; use-package, require or autoloads to do so when the user provides
+;; appropriate configuration.
+(package-initialize t)
 (unless package-archive-contents
   (package-refresh-contents))
+
+(unless (package-installed-p 'use-package)
+  (package-install 'use-package))
 
 (provide 'rational-use-package)
 ;;; rational-use-package.el ends here


### PR DESCRIPTION
It seemed odd to use straight to install `use-package`, when the rest
of this module is about using package.el. Update priorities to pull
from gnu/nongnu elpas over melpa per the principles, install
`use-package` from one of the elpas if it is not already
installed. Also do not activate packages when calling
`package-initialize`, prefer to allow `use-package`, `require`, or
`autoload` to activate packages as needed by the user.