### PR TITLE
Load theme instead of setting default fg/bg color

### DIFF
--- a/early-init.el
+++ b/early-init.el
@@ -26,9 +26,10 @@
 (push '(tool-bar-lines . 0) default-frame-alist)
 (push '(menu-bar-lines . 0) default-frame-alist)
 (push '(vertical-scroll-bars) default-frame-alist)
-(push '(background-color . "#232635") default-frame-alist)
-(push '(foreground-color . "#FFFFFF") default-frame-alist)
 (push '(mouse-color . "white") default-frame-alist)
+
+;; Loads a nice blue theme, avoids the white screen flash on startup.
+(load-theme 'deeper-blue t)
 
 ;; Make the initial buffer load faster by setting its mode to fundamental-mode
 (setq initial-major-mode 'fundamental-mode)


### PR DESCRIPTION
Configuring the default foreground and background color takes extra
effort to undo when loading a theme after early-init processes. See
#37 for commentary and resolution.

Loads the deeper-blue theme as that one is built-in and matches
closely the default colors.