### PR TITLE
Fix rational modules skeleton regex

### DIFF
--- a/init.el
+++ b/init.el
@@ -62,7 +62,8 @@ straight.el or Guix depending on the value of
 (auto-insert-mode)
 (with-eval-after-load "autoinsert"
   (define-auto-insert
-    (cons "rational-.*\\.el" "Rational Emacs Lisp Skeleton")
+    (cons (concat (expand-file-name user-emacs-directory) "modules/rational-.*\\.el")
+          "Rational Emacs Lisp Skeleton")
     '("Rational Emacs Module Description: "
       ";;;; " (file-name-nondirectory (buffer-file-name)) " --- " str
       (make-string (max 2 (- 80 (current-column) 27)) ?\s)


### PR DESCRIPTION
Expected the regex to only apply to the filename without the path,
however, the code uses `buffer-file-name` which includes the path. So
personal modules whose path matched the regex resulted in the module
skeleton insertion which was not intended. This should fix #89 and
only insert for elisp files found in the modules folder and named
rational-[ *module* ].el