### PR TITLE
(init.el) Use Emacs (emacs-init-time) to get init time.

### DIFF
--- a/init.el
+++ b/init.el
@@ -4,7 +4,7 @@
 (add-hook 'emacs-startup-hook
           (lambda ()
             (message "Rational Emacs loaded in %s."
-                     (format "%.2f seconds" (emacs-init-time)))))
+                     (emacs-init-time))))
 
 ;; Add the modules folder to the load path
 (add-to-list 'load-path (expand-file-name "modules/" user-emacs-directory))

--- a/init.el
+++ b/init.el
@@ -4,9 +4,7 @@
 (add-hook 'emacs-startup-hook
           (lambda ()
             (message "Rational Emacs loaded in %s."
-                     (format "%.2f seconds"
-                             (float-time
-                              (time-subtract after-init-time before-init-time))))))
+                     (format "%.2f seconds" (emacs-init-time)))))
 
 ;; Add the modules folder to the load path
 (add-to-list 'load-path (expand-file-name "modules/" user-emacs-directory))


### PR DESCRIPTION
This PR make use of Emacs `emacs-init-time` function to calculate the time it takes to load Emacs `early-init.el` and `init.el`.