### PR TITLE
Correct the Example Configuration; Add more commentary to rational-ui.el

### DIFF
--- a/README.org
+++ b/README.org
@@ -185,7 +185,7 @@ filesystem, it is created. However, just the path is created, the files
   ;; Set further font and theme customizations
   (custom-set-variables
    '(rational-ui-default-font
-     '(:font "JetBrains Mono" :weight 'light :height 185)))
+     '(:font "JetBrains Mono" :weight light :height 185)))
 
   (load-theme 'doom-snazzy t)
 

--- a/modules/rational-ui.el
+++ b/modules/rational-ui.el
@@ -10,6 +10,20 @@
 ;; User interface customizations. Examples are the modeline and how
 ;; help buffers are displayed.
 
+;; This package provides a basic, customized appearance for
+;; Emacs. Specifically, it uses: Helpful to customize the information
+;; and visual display of help buffers, such as that created by M-x
+;; `describe-function'; Doom Modeline and Themes, to customize the
+;; appearance of buffers, text, et cetera; All-the-icons, to provide
+;; Doom Modeline with font-based icons (rather than raster or vector
+;; images); and includes some Emacs Lisp demonstrations.
+
+;;  Run `all-the-icons-install-fonts' to ensure the fonts necessary
+;; for ALL THE ICONS are available on your system. You must run this
+;; function if the "stop" icon at the beginning of this paragraph is
+;; not displayed properly (it appears as a box with some numbers
+;; and/or letters inside it).
+
 ;;; Code:
 
 (straight-use-package 'all-the-icons)


### PR DESCRIPTION
The example configuration now uses an unquoted symbol in the weight face attribute plist, as M-x `customize-group` "rational" would do when customizing the variable.

Using the example configuration on the current HEAD causes an error, because the symbolp fails; this may confuse some users, because the predicate will pass interactively.