### PR TITLE
Add a warning when building `all-the-icons.el' on Windows

### DIFF
--- a/modules/rational-ui.el
+++ b/modules/rational-ui.el
@@ -16,7 +16,7 @@
 			:post-build ((when ON-WINDOWS
 				       (warn
 					"%s"
-					"Read the commentary for `rational-ui.el'; on Windows, `all-the-icons-install-fonts' only downloads fonts, they must be installed manually.")))))
+					"Read the documentation for `all-the-icons'; on Windows, `all-the-icons-install-fonts' only downloads fonts, they must be installed manually. This is necessary if icons are not displaying properly.")))))
 (straight-use-package 'doom-modeline)
 (straight-use-package 'doom-themes)
 (straight-use-package 'elisp-demos)

--- a/modules/rational-ui.el
+++ b/modules/rational-ui.el
@@ -12,7 +12,11 @@
 
 ;;; Code:
 
-(straight-use-package 'all-the-icons)
+(straight-use-package '(all-the-icons
+			:post-build ((when ON-WINDOWS
+				       (warn
+					"%s"
+					"Read the commentary for `rational-ui.el'; on Windows, `all-the-icons-install-fonts' only downloads fonts, they must be installed manually.")))))
 (straight-use-package 'doom-modeline)
 (straight-use-package 'doom-themes)
 (straight-use-package 'elisp-demos)


### PR DESCRIPTION
This informs the user with a warning that `all-the-icons-install-fonts` merely downloads fonts, and they must be intalled manually if icons are not displayed properly.

Assists users encountering #80, but does not resolve that issue as it is system dependent.