### PR TITLE
Add whitespace configuration

### DIFF
--- a/modules/rational-defaults.el
+++ b/modules/rational-defaults.el
@@ -55,5 +55,11 @@
 ;; Enable savehist-mode for an command history
 (savehist-mode 1)
 
+;; whitespace
+(customize-set-variable 'whitespace-style
+                        '(face tabs empty trailing tab-mark indentation::space))
+(customize-set-variable 'whitespace-action '(cleanup auto-cleanup))
+(global-whitespace-mode)
+
 (provide 'rational-defaults)
 ;;; rational-defaults.el ends here


### PR DESCRIPTION
After feedback on #93, split whitespace configuration to its own PR. 

`whitespace.el` is built-in to Emacs, provides visualization of whitespace at ends of lines or where tabs are used, etc. This configuration turns on those features as well as configures whitespace.el to cleanup whitespace on save. 