### PR TITLE
Remove ws-butler in favor of whitespace.el

### DIFF
--- a/modules/rational-editing.el
+++ b/modules/rational-editing.el
@@ -11,15 +11,17 @@
 
 ;;; Code:
 
-(straight-use-package 'ws-butler)
 (straight-use-package 'evil-nerd-commenter)
-
-;; Set up ws-butler for trimming whitespace and line endings
-(add-hook 'text-mode-hook 'ws-butler-mode)
-(add-hook 'prog-mode-hook 'ws-butler-mode)
 
 ;; Set a global binding for better line commenting/uncommenting
 (global-set-key (kbd "M-/") 'evilnc-comment-or-uncomment-lines)
+
+;; whitespace
+(customize-set-variable 'whitespace-style
+                        '(face tabs empty trailing tab-mark indentation::space))
+(customize-set-variable 'whitespace-action '(cleanup auto-cleanup))
+(add-hook 'prog-mode-hook #'whitespace-mode)
+(add-hook 'text-mode-hook #'whitespace-mode)
 
 ;; parentheses
 (electric-pair-mode 1) ; auto-insert matching bracket


### PR DESCRIPTION
whitespace.el provides what ws-butler was doing and is built
in. Following the principles, preferring whitespace.el.