### PR TITLE
Remap comment-dwim rather than dabbrev-expand key

### DIFF
--- a/modules/rational-editing.el
+++ b/modules/rational-editing.el
@@ -14,7 +14,7 @@
 (straight-use-package 'evil-nerd-commenter)
 
 ;; Set a global binding for better line commenting/uncommenting
-(global-set-key (kbd "M-/") 'evilnc-comment-or-uncomment-lines)
+(define-key global-map [remap comment-dwim] #'evilnc-comment-or-uncomment-lines)
 
 ;; whitespace
 (customize-set-variable 'whitespace-style


### PR DESCRIPTION
M-/ is used for dabbrev-expand while M-; is used for
comment-dwim. Prefer to remap the exisiting comment behavior for
evil-nerd-commenter rather than override the conflicting key used for
dabbrev expansion.