### PR TITLE
Add existing custom variables to the Rational customization group

### DIFF
--- a/modules/rational-evil.el
+++ b/modules/rational-evil.el
@@ -13,8 +13,9 @@
 
 ;; Define configuration variables
 (defcustom rational-evil-discourage-arrow-keys nil
-  "When t, prevent the use of arrow keys in normal state to
-encourage the use of Vim-style movement keys (hjkl).")
+  "When non-nil, prevent navigation with the arrow keys in Normal state."
+  :group 'rational
+  :type 'boolean)
 
 ;; Install dependencies
 (straight-use-package 'evil)

--- a/modules/rational-updates.el
+++ b/modules/rational-updates.el
@@ -76,8 +76,14 @@ and don't prompt for confirmation."
       (rational-updates--pull-commits)
     (rational-updates-show-latest)))
 
+;; TODO: use a derived type to check that the value is something `run-at-time'
+;; will accept
 (defcustom rational-updates-fetch-interval "24 hours"
-  "The interval at which `rational-updates-mode' will check for updates."
+  "The interval at which `rational-updates-mode' will check for updates.
+
+The interval is scheduled with `run-at-time', so the value of
+this variable must conform to a format accepted by
+`run-at-time'."
   :group 'rational)
 
 (defun rational-updates--do-automatic-fetch ()

--- a/modules/rational-windows.el
+++ b/modules/rational-windows.el
@@ -12,10 +12,14 @@
 ;;; Code:
 
 (defcustom rational-windows-evil-style nil
-  "When t, window movement bindings will be evil-style.")
+  "When non-nil, window movement will use evil-style bindings."
+  :group 'rational
+  :type 'boolean)
 
 (defcustom rational-windows-prefix-key "C-c w"
-  "Configure the prefix key for `rational-windows' bindings.")
+  "Configure the prefix key for `rational-windows' bindings."
+  :group 'rational
+  :type 'key)
 
 (winner-mode 1)
 


### PR DESCRIPTION
- Add `:group 'rational` for each `defcustom` in the modules without that
- Add a `:type` value for each customization variable for which a type is sensible