### PR TITLE
activate org-appear when org-mode is activated

### DIFF
--- a/modules/rational-org.el
+++ b/modules/rational-org.el
@@ -22,7 +22,7 @@
 
 ;; Hide markup markers
 (setq org-hide-emphasis-markers t)
-(add-hook 'org-mode 'org-appear-mode)
+(add-hook 'org-mode-hook 'org-appear-mode)
 
 (provide 'rational-org)
 ;;; rational-org.el ends here


### PR DESCRIPTION
Following the installation and usage instructions of [org-appear](https://github.com/awth13/org-appear) it seems that org-appear-mode was added to the wrong hook and didn't get activated 