### PR TITLE
Disable auto-pairing of "<" in org-mode

### DIFF
--- a/modules/rational-completion.el
+++ b/modules/rational-completion.el
@@ -76,5 +76,11 @@ folder, otherwise delete a word"
 ;; Use Embark to show bindings in a key prefix with `C-h`
 (setq prefix-help-command #'embark-prefix-help-command)
 
+;; disable auto-pairing of "<" in org-mode
+(add-hook 'org-mode-hook (lambda ()
+    (setq-local electric-pair-inhibit-predicate
+    `(lambda (c)
+        (if (char-equal c ?<) t (,electric-pair-inhibit-predicate c))))))
+
 (provide 'rational-completion)
 ;;; rational-completion.el ends here

--- a/modules/rational-completion.el
+++ b/modules/rational-completion.el
@@ -76,11 +76,5 @@ folder, otherwise delete a word"
 ;; Use Embark to show bindings in a key prefix with `C-h`
 (setq prefix-help-command #'embark-prefix-help-command)
 
-;; disable auto-pairing of "<" in org-mode
-(add-hook 'org-mode-hook (lambda ()
-    (setq-local electric-pair-inhibit-predicate
-    `(lambda (c)
-        (if (char-equal c ?<) t (,electric-pair-inhibit-predicate c))))))
-
 (provide 'rational-completion)
 ;;; rational-completion.el ends here

--- a/modules/rational-org.el
+++ b/modules/rational-org.el
@@ -24,5 +24,11 @@
 (customize-set-variable 'org-hide-emphasis-markers t)
 (add-hook 'org-mode-hook 'org-appear-mode)
 
+;; disable auto-pairing of "<" in org-mode
+(add-hook 'org-mode-hook (lambda ()
+    (setq-local electric-pair-inhibit-predicate
+    `(lambda (c)
+        (if (char-equal c ?<) t (,electric-pair-inhibit-predicate c))))))
+
 (provide 'rational-org)
 ;;; rational-org.el ends here


### PR DESCRIPTION
With the example config, electric-pair-mode is active in org-mode and it pairs all brackets, including "<>".
While that *is* useful for e.g. manually entering agenda dates, I propose  to disable it by default, because

a) most people probably use functions like `org-schedule` for those
b) many useful [snippets](https://github.com/AndreaCrotti/yasnippet-snippets/tree/master/snippets/org-mode) from the widely used yasnippet package begin with "<".

I've taken the liberty to prepare a PR disabling it in the module `rational-completion`, but I'm unsure whether that's the best place for this bit of code. If you want it, at all, that is.