### PR TITLE
Change theme in example-config.el to `doom-one`

### DIFF
--- a/README.org
+++ b/README.org
@@ -192,7 +192,7 @@ filesystem, it is created. However, just the path is created, the files
    '(rational-ui-default-font
      '(:font "JetBrains Mono" :weight light :height 185)))
 
-  (load-theme 'doom-snazzy t)
+  (load-theme 'doom-one t)
 
   ;; To not load `custom.el' after `config.el', uncomment this line.
   ;; (setq rational-load-custom-file nil)

--- a/docs/rational-emacs.info
+++ b/docs/rational-emacs.info
@@ -256,7 +256,7 @@ File: rational-emacs.info,  Node: Example Configuration,  Next: The customel fil
       '(rational-ui-default-font
         '(:font "JetBrains Mono" :weight light :height 185)))
 
-     (load-theme 'doom-snazzy t)
+     (load-theme 'doom-one t)
 
 
 
@@ -345,7 +345,7 @@ have something that looks more like this:
      (require 'rational-completion)
      (require 'rational-windows)
 
-     (load-theme 'doom-snazzy t)
+     (load-theme 'doom-one t)
 
      (load "custom")
      ;;; example-config.el ends here
@@ -401,7 +401,7 @@ once.  Here is the same example written differently.
                              '(:font "JetBrains Mono" :weight light :height 185))
      (customize-set-variable 'rational-ui-display-line-numbers t)
 
-     (load-theme 'doom-snazzy t)
+     (load-theme 'doom-one t)
 
 
 Listing 3.5: Example ‘config.el’ setting customization variables

--- a/docs/rational-emacs.org
+++ b/docs/rational-emacs.org
@@ -172,7 +172,7 @@ Emacs configuration journey.
      '(rational-ui-default-font
        '(:font "JetBrains Mono" :weight light :height 185)))
 
-    (load-theme 'doom-snazzy t)
+    (load-theme 'doom-one t)
 
   #+end_src
 
@@ -243,7 +243,7 @@ Emacs configuration journey.
       (require 'rational-completion)
       (require 'rational-windows)
 
-      (load-theme 'doom-snazzy t)
+      (load-theme 'doom-one t)
 
       (load "custom")
       ;;; example-config.el ends here
@@ -297,7 +297,7 @@ Emacs configuration journey.
                               '(:font "JetBrains Mono" :weight light :height 185))
       (customize-set-variable 'rational-ui-display-line-numbers t)
 
-      (load-theme 'doom-snazzy t)
+      (load-theme 'doom-one t)
     #+end_src
 
 *** Caveat on the timing of loading =custom.el=

--- a/example-config.el
+++ b/example-config.el
@@ -25,7 +25,7 @@
    '(rational-ui-default-font
      '(:font "JetBrains Mono" :weight light :height 185)))
 
-(load-theme 'doom-snazzy t)
+(load-theme 'doom-one t)
 
 ;; To not load `custom.el' after `config.el', uncomment this line.
 ;; (setq rational-load-custom-file nil)

--- a/examples/general/example-config.el
+++ b/examples/general/example-config.el
@@ -25,7 +25,7 @@
    '(rational-ui-default-font
      '(:font "JetBrains Mono" :weight light :height 185)))
 
-(load-theme 'doom-snazzy t)
+(load-theme 'doom-one t)
 
 ;; To not load `custom.el' after `config.el', uncomment this line.
 ;; (setq rational-load-custom-file nil)


### PR DESCRIPTION
In its current state, starting a fresh install of rational emacs with the example config fails. 
One reason is that it tries to load `doom-snazzy`, which isn't available the last versioned release of doom-themes.

`doom-one` has a similar look and is available.