### PR TITLE
Ignore `bookmarks` file which shall never be commited

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ eshell/
 rational-emacs/
 projects
 elpa/
+bookmarks


### PR DESCRIPTION
Emacs default bookmarks file is within `user-emacs-directory`.
So maybe add it to `.gitignore`