### PR TITLE
Move all theme related stuff to the Example

### DIFF
--- a/README.org
+++ b/README.org
@@ -192,6 +192,8 @@ filesystem, it is created. However, just the path is created, the files
    '(rational-ui-default-font
      '(:font "JetBrains Mono" :weight light :height 185)))
 
+  ;; Install and load your theme
+  (rational-package-install-package 'doom-themes)
   (load-theme 'doom-one t)
 
   ;; To not load `custom.el' after `config.el', uncomment this line.

--- a/modules/rational-ui.el
+++ b/modules/rational-ui.el
@@ -33,7 +33,6 @@
 
 (rational-package-install-package 'all-the-icons)
 (rational-package-install-package 'doom-modeline)
-(rational-package-install-package 'doom-themes)
 (rational-package-install-package 'elisp-demos)
 (rational-package-install-package 'helpful)
 


### PR DESCRIPTION
See discussion in #133.
Theme related stuff is now only in the example configuration with a note to make it clear to the user they should load some theme.

Closes #133.