### PR TITLE
Add doom-themes installation to examples and docs

### DIFF
--- a/docs/rational-emacs.info
+++ b/docs/rational-emacs.info
@@ -256,6 +256,7 @@ File: rational-emacs.info,  Node: Example Configuration,  Next: The customel fil
       '(rational-ui-default-font
         '(:font "JetBrains Mono" :weight light :height 185)))
 
+     (rational-package-install-package 'doom-themes)
      (load-theme 'doom-one t)
 
 
@@ -345,6 +346,7 @@ have something that looks more like this:
      (require 'rational-completion)
      (require 'rational-windows)
 
+     (rational-package-install-package 'doom-themes)
      (load-theme 'doom-one t)
 
      (load "custom")
@@ -401,6 +403,7 @@ once.  Here is the same example written differently.
                              '(:font "JetBrains Mono" :weight light :height 185))
      (customize-set-variable 'rational-ui-display-line-numbers t)
 
+     (rational-package-install-package 'doom-themes)
      (load-theme 'doom-one t)
 
 

--- a/docs/rational-emacs.org
+++ b/docs/rational-emacs.org
@@ -172,6 +172,7 @@ Emacs configuration journey.
      '(rational-ui-default-font
        '(:font "JetBrains Mono" :weight light :height 185)))
 
+    (rational-package-install-package 'doom-themes)
     (load-theme 'doom-one t)
 
   #+end_src
@@ -243,6 +244,7 @@ Emacs configuration journey.
       (require 'rational-completion)
       (require 'rational-windows)
 
+      (rational-package-install-package 'doom-themes)
       (load-theme 'doom-one t)
 
       (load "custom")
@@ -294,9 +296,10 @@ Emacs configuration journey.
       (require 'rational-windows)
 
       (customize-set-variable 'rational-ui-default-font
-                              '(:font "JetBrains Mono" :weight light :height 185))
+			      '(:font "JetBrains Mono" :weight light :height 185))
       (customize-set-variable 'rational-ui-display-line-numbers t)
 
+      (rational-package-install-package 'doom-themes)
       (load-theme 'doom-one t)
     #+end_src
 

--- a/example-config.el
+++ b/example-config.el
@@ -25,6 +25,7 @@
    '(rational-ui-default-font
      '(:font "JetBrains Mono" :weight light :height 185)))
 
+(rational-package-install-package 'doom-themes)
 (load-theme 'doom-one t)
 
 ;; To not load `custom.el' after `config.el', uncomment this line.

--- a/examples/general/example-config.el
+++ b/examples/general/example-config.el
@@ -25,6 +25,7 @@
    '(rational-ui-default-font
      '(:font "JetBrains Mono" :weight light :height 185)))
 
+(rational-package-install-package 'doom-themes)
 (load-theme 'doom-one t)
 
 ;; To not load `custom.el' after `config.el', uncomment this line.


### PR DESCRIPTION
Since #138 the loading of doom-one requires installation of
`doom-themes` by the user. It's only present in one example. This
adds it to all examples and docs.

So - depending on which example config file the user starts out with - a new user might end up with an error instead of a successful startup of Emacs.

Alternatively, we could remove the loading of `doom-one` from all examples and docs.