### PR TITLE
Run package-contents-refresh in the background for stale archives

### DIFF
--- a/init.el
+++ b/init.el
@@ -44,9 +44,15 @@ Return non-nil if the on-disk cache is older than one day or
  ;; `package-archive-contents' has not been initialized. If Emacs has
  ;; been running for a while, user will need to manually run
  ;; `package-refresh-contents' before calling `package-install'.
- (when (or (seq-empty-p package-archive-contents)
-           (rational-package-archives-stale-p))
-   (package-refresh-contents)))
+ (cond ((seq-empty-p package-archive-contents)
+        (progn
+          (message "rational-init: package archives empty, initializing")
+          (package-refresh-contents)))
+       ((rational-package-archives-stale-p)
+        (progn
+          (message "rational-init: package archives stale, refreshing in the background")
+          (package-refresh-contents t))))
+ )
 
 ;; Add the modules folder to the load path
 (add-to-list 'load-path (expand-file-name "modules/" user-emacs-directory))


### PR DESCRIPTION
Though it makes sense to do it synchronously when the archive is empty,
the refresh due to stale archives could be done in the background thus greatly improving startup time.

Otherwise your first start every morning can take a while.