### PR TITLE
Proposal to fix issue #144

### DIFF
--- a/modules/rational-compile.el
+++ b/modules/rational-compile.el
@@ -79,13 +79,13 @@ directories defined in `rational-compile-modules-path' and
 It returns the first source-file that matches for the MODULE in
 the order specified search path.  If it finds none, it retorns
 nil."
-  (expand-file-name
-   (format "%s.el" (symbol-name module))
-   (seq-find (lambda (dir)
+  (let ((dir (seq-find (lambda (dir)
                (file-exists-p (expand-file-name (format "%s.el" (symbol-name module)) dir)))
              (or path
                  (flatten-list `(,rational-compile-modules-path
                                  ,rational-compile-extra-directories-list))))))
+    (when dir
+      (expand-file-name (format "%s.el" (symbol-name module)) dir))))
 
 ;; A function to compile a specific file
 (defun rational-compile-file (f)

--- a/modules/rational-compile.el
+++ b/modules/rational-compile.el
@@ -21,28 +21,59 @@
 
 ;;; Code:
 
+
 ;;;; Variables:
-;; We define a variable to enable/disable modules autocompilation.
+;; We define a variable to enable/disable modules compilation.
 (defvar rational-compile-modules t
-  "When non-nil, autocompile emacs lisp sources for the modules on startup.")
+  "When non-nil, compile emacs lisp sources for the modules on startup.")
+
+;; We define a variable to enable/disable user's modules compilation.
+(defvar rational-compile-user-modules t
+  "When non-nil, compile user's emacs lisp sources for the modules on startup.")
+
+(defvar rational-compile-module-list '()
+  "A list of modules to compile.")
+
+(defvar rational-compile-modules-path
+  `(,(expand-file-name "modules" rational-config-path)
+    ,(expand-file-name "modules" user-emacs-directory))
+  "Path where to locate modules.")
 
 (defvar rational-compile-user-configuration t
-  "When non-nil, autocompile emacs lisp sources for the modules on startup.")
+  "When non-nil, compile emacs lisp sources for the modules on startup.")
 
 (defvar rational-compile-init-files nil
-  "When non-nil, autocompile init files on startup.")
+  "When non-nil, compile init files on startup.")
 
 (defvar rational-compile-on-save nil
-  "When non-nil, autocompile the file after saving it.")
+  "When non-nil, compile the file after saving it.")
 
 (defvar rational-compile-extra-directories-list nil
-  "List of extra directories to autocompile.")
+  "List of extra directories to compile.")
 
 (defvar rational-compile-init-files-list
   '("early-init.el" "init.el")
   "List of initialization file names.")
 
+(defvar rational-compile-config-files-list
+  '("early-config.el" "config.el")
+  "List of configuration file names.")
+
+
 ;;;; Functions:
+;; A function to locate a module's source file:
+(defun rational-locate-module-file (module &optional path)
+  (setq-local module-path nil)
+  (dolist (dir (or path
+                   (flatten-list `(,rational-compile-modules-path
+                                   ,rational-compile-extra-directories-list))))
+    (let ((file (expand-file-name (format "%s.el" (symbol-name module)) dir)))
+      (when (and (file-exists-p file)
+                 (not module-path))
+        (setq-local module-path file))))
+  module-path)
+
+
 ;; A function to compile a specific file
 (defun rational-compile-file (f)
   "Compiles (native or byte-code) the file F.
@@ -88,8 +119,8 @@ D could be a single directory or a list of directories."
   "Returns a list of configured directories to autocompile."
   (flatten-list `(,(and rational-compile-modules
                         (expand-file-name "modules/" user-emacs-directory))
-                  ,(and rational-compile-user-configuration
-                        (expand-file-name "./" rational-config-path))
+                  ,(and rational-compile-user-modules
+                        (expand-file-name "modules/" rational-config-path))
                   ,rational-compile-extra-directories-list)))
 
 ;; A function to get the list of init files with full path:
@@ -99,12 +130,58 @@ D could be a single directory or a list of directories."
             (expand-file-name f user-emacs-directory))
           rational-compile-init-files-list))
 
-;; A function to execute the compilation of the modules directory:
+(defun rational-compile--config-files-list ()
+  "Returns a list of the init files."
+  (mapcar (lambda (f)
+            (expand-file-name f rational-config-path))
+          rational-compile-config-files-list))
+;;(rational-compile--config-files-list)
+
+;; A function to execute the compilation of the modules within the list:
 (defun rational-compile-modules ()
-  "Compile (native or byte-code) the modules' source code for faster startups."
+  "Compile specific files defined in `rational-compile-module-list'.
+
+If `rational-compile-init-files' is non-nil, then it compiles
+the init-files (`rational-compile-init-files-list') within
+`user-emacs-directory'.
+
+If `rational-compile-user-configuration' is non-nil, then it
+compiles the config-files (`rational-compile-config-files-list')
+within `rational-config-path'.
+
+If `rational-compile-modules' is non-nil, then it compiles all
+the source-files for the modules defined in
+`rational-compile-module-list' within the subdirectory 'modules'
+in `user-emacs-directory', or in any directory specified in
+`rational-compile-extra-directories-list'.
+
+If `rational-compile-user-modules' is non-nil, then it compiles
+all the source-files for the modules defined in
+`rational-compile-module-list' within the subdirectory 'modules'
+in `rational-config-path'.
+
+If any source-file for any module specified in
+`rational-compile-module-list' doesn't exist within the paths
+specified, then it is ignored without a warning."
   (interactive)
-  (rational-compile-directory
-   (rational-compile--config-dirs-list)))
+  (when rational-compile-init-files
+    (rational-compile-init))
+  (when rational-compile-user-configuration
+    (rational-compile-config))
+  (when rational-compile-modules
+    (dolist (module rational-compile-module-list)
+      (let ((module-src (rational-locate-module-file module
+                                                     (flatten-list
+                                                      `(,(expand-file-name "modules/" user-emacs-directory)
+                                                        ,rational-compile-extra-directories-list))))
+        (when module-src
+          (rational-compile-file module-src))))))
+  (when rational-compile-user-modules
+    (dolist (module rational-compile-module-list)
+      (let ((module-src (rational-locate-module-file module
+                                                     `(,(expand-file-name "modules/" rational-config-path)))))
+        (when module-src
+          (rational-compile-file module-src))))))
 
 ;; A funciton to execute the compilation of the init files:
 (defun rational-compile-init ()
@@ -115,6 +192,16 @@ The files to be compiled is defined in
   (interactive)
   (rational-compile-file (rational-compile--init-files-list)))
 
+;; A funciton to execute the compilation of the config files:
+(defun rational-compile-config ()
+  "Compile (native or byte-code) the configuration files.
+
+The files to be compiled is defined in
+`rational-compile-config-files-list'."
+  (interactive)
+  (rational-compile-file (rational-compile--init-config-list)))
+
+
 ;;;; Hooks:
 
 ;;;;; Modules
@@ -125,19 +212,10 @@ The files to be compiled is defined in
 (add-hook 'emacs-startup-hook ;; or kill-emacs-hook?
           (lambda ()
             (when (or rational-compile-modules
+                      rational-compile-user-modules
+                      rational-compile-init-files
                       rational-compile-user-configuration)
               (rational-compile-modules))))
-
-;;;;; Init files
-;; To autocompile init files.  This could be toggled by setting
-;; `rational-compile-init-files' or
-;; `rational-compile-user-configuration' either to `nil' or
-;; `t'.
-(add-hook 'emacs-startup-hook ;; or kill-emacs-hook?
-          (lambda ()
-            (when (or rational-compile-init-files
-                      rational-compile-user-configuration)
-              (rational-compile-init))))
 
 ;;;;; On save files
 ;; To auto compile after saving the file.  This could be toggled by

--- a/modules/rational-compile.el
+++ b/modules/rational-compile.el
@@ -86,8 +86,7 @@ nil."
                          (or path
                              (flatten-list `(,rational-compile-modules-path
                                              ,rational-compile-extra-directories-list)))))))
-      (when (file-exists-p file)
-        file)))
+        file))
 
 ;; A function to compile a specific file
 (defun rational-compile-file (f)

--- a/modules/rational-compile.el
+++ b/modules/rational-compile.el
@@ -79,14 +79,13 @@ directories defined in `rational-compile-modules-path' and
 It returns the first source-file that matches for the MODULE in
 the order specified search path.  If it finds none, it retorns
 nil."
-  (let ((file (expand-file-name
-               (format "%s.el" (symbol-name module))
-               (seq-find (lambda (dir)
-                           (file-exists-p (expand-file-name (format "%s.el" (symbol-name module)) dir)))
-                         (or path
-                             (flatten-list `(,rational-compile-modules-path
-                                             ,rational-compile-extra-directories-list)))))))
-        file))
+  (expand-file-name
+   (format "%s.el" (symbol-name module))
+   (seq-find (lambda (dir)
+               (file-exists-p (expand-file-name (format "%s.el" (symbol-name module)) dir)))
+             (or path
+                 (flatten-list `(,rational-compile-modules-path
+                                 ,rational-compile-extra-directories-list))))))
 
 ;; A function to compile a specific file
 (defun rational-compile-file (f)


### PR DESCRIPTION
This is a proposal to fix issue #144.

It will require to the user to mantain the list of modules to compile using the variable `rational-compile-module-list'.

If a tool (function or macro) will be developed to keep track of both requires and the mantainance of the module list to be compiled, it will be on another module.

I also made some minor modifications that had sense no more with this update, but I tried to keep the interface intact.