### PR TITLE
Enhance whitespace configutation (#107)

### DIFF
--- a/modules/rational-editing.el
+++ b/modules/rational-editing.el
@@ -11,12 +11,67 @@
 
 ;;; Code:
 
-;; whitespace
-(customize-set-variable 'whitespace-style
-                        '(face tabs empty trailing tab-mark indentation::space))
+;; Customization group for the Rational Editing module.
+(defgroup rational-editing '()
+  "Editing related configuration for Rational Emacs."
+  :tag "Editing"
+  :group 'rational)
+
+(defun rational-editing--prefer-tabs (enable)
+  "Adjust whitespace configuration to support tabs based on ENABLE."
+  (if enable
+      (customize-set-variable 'whitespace-style
+                              '(face empty trailing indentation::tab
+                                     space-after-tab::tab
+                                     space-before-tab::tab))
+    (customize-set-variable 'whitespace-style
+                            '(face empty trailing tab-mark
+                                   indentation::space))))
+
+(defun rational-editing--enable-whitespace-modes (modes)
+  "Enable whitespace-mode for each mode specified by MODES."
+  (dolist (mode modes)
+    (add-hook (intern (format "%s-hook" mode))
+              #'whitespace-mode)))
+
+(defun rational-editing--disable-whitespace-modes (modes)
+  "Do not enable whitespace-mode for each mode specified by MODES."
+  (dolist (mode modes)
+    (remove-hook (intern (format "%s-hook" mode))
+                 #'whitespace-mode)))
+
+;; provide an option for users who prefer tabs over spaces
+(defcustom rational-editing-prefer-tabs nil
+  "Prefer using tabs instead of spaces."
+  :tag "Prefer tabs over spaces"
+  :group 'rational-editing
+  :set (lambda (sym val)
+         (set-default sym val)
+         (rational-editing--prefer-tabs val)))
+
+;; whitespace cleanup configuration
+(defcustom rational-editing-whitespace-cleanup-enabled-modes
+  '(conf-mode prog-mode)
+  "Modes which should have whitespace cleanup enabled."
+  :type 'list
+  :tag "Whitespace cleanup enabled modes"
+  :group 'rational-editing
+  :set (lambda (sym val)
+         (set-default sym val)
+         (rational-editing--enable-whitespace-modes val)))
+
+(defcustom rational-editing-whitespace-cleanup-disabled-modes
+  '(makefile-mode)
+  "Modes which should not have whitespace cleanup enabled."
+  :type 'list
+  :tag "Whitespace cleanup disabled modes"
+  :group 'rational-editing
+  :set (lambda (sym val)
+         (set-default sym val)
+         (rational-editing--disable-whitespace-modes val)))
+
+;; cleanup whitespace
 (customize-set-variable 'whitespace-action '(cleanup auto-cleanup))
-(add-hook 'prog-mode-hook #'whitespace-mode)
-(add-hook 'text-mode-hook #'whitespace-mode)
 
 ;; parentheses
 (electric-pair-mode 1) ; auto-insert matching bracket


### PR DESCRIPTION
Fixes #107.

Provides three new customization variables for controlling how whitespace visualization and cleanup works.

1. `rational-editing-prefer-tabs`: Can be set to `t` which cases the whitespace mode and cleanup to highlight/cleanup spaces where tabs should be, setting this to `nil` (the default) highlights tabs and replaces them with spaces on cleanup (preserving the `whitespace-style` settings which were in this  configuration).
2. `rational-editing-whitespace-cleanup-modes-enabled`: List of modes to perform whitespace cleanup/visualization.
3. `rational-editing-whitespace-cleanup-modes-disabled`: List of modes which should not do whitespace cleanup/visualization.

The `rational-editing-prefer-tabs` to address requirement raised by @erikLundstedt (support for tabs-only person) in #107. Setting this to `t` does NOT change the value of `indent-tabs-mode`. Doing so globally can have very unexpected side-effects and should (in my opinion) be handled local to a buffer. It does not work as a simple "switch" to use tabs instead of spaces (there really is no such thing in Emacs). The handler for `rational-editing-prefer-tabs` could be extended in the future to provide additional configuration for those who prefer tabs over spaces (maybe by someone who uses that mode extensively and knows the proper way to handle it - I do not).

I've added `makefile-mode` to the disabled list, since it is know to have problems with whitespace cleanup. If anyone is aware of other modes which behave badly with auto-whitespace cleanup, please let me know and I can add it to the default value.
