### PR TITLE
Load `embark-consult`

### DIFF
--- a/modules/rational-completion.el
+++ b/modules/rational-completion.el
@@ -19,6 +19,7 @@
 (rational-package-install-package 'orderless)
 (rational-package-install-package 'marginalia)
 (rational-package-install-package 'embark)
+(rational-package-install-package 'embark-consult)
 
 (defun rational-completion/minibuffer-backward-kill (arg)
   "When minibuffer is completing a file name delete up to parent
@@ -69,12 +70,17 @@ folder, otherwise delete a word"
 (setq completion-category-defaults nil)
 
 ;;;; Embark
+(require 'embark)
+(require 'embark-consult)
 
 (global-set-key [remap describe-bindings] #'embark-bindings)
 (global-set-key (kbd "C-.") 'embark-act)
 
 ;; Use Embark to show bindings in a key prefix with `C-h`
 (setq prefix-help-command #'embark-prefix-help-command)
+
+(with-eval-after-load 'embark-consult
+  (add-hook 'embark-collect-mode-hook #'consult-preview-at-point-mode))
 
 (provide 'rational-completion)
 ;;; rational-completion.el ends here


### PR DESCRIPTION
According to [the embark README](https://github.com/oantolin/embark)
users of both `consult` and `embark` should load `embark-consult`:

> If you use the grepping commands from the Consult package, consult-grep, consult-git-grep or consult-ripgrep, then you’ll probably want to install and load the embark-consult package, which adds support for exporting a list of grep results to an honest grep-mode buffer, on which you can even use wgrep if you wish.

We use `with-eval-after-load`, regardless both packages are loaded and required
in `rational-completetion`.