### PR TITLE
Draft: Introduce rational-config-path

### DIFF
--- a/README.org
+++ b/README.org
@@ -136,6 +136,9 @@ information about how they can be configured!
 - rational-shell :: A starter configuration for =eshell= and =vterm=
 
 * Customization
+:PROPERTIES:
+:CUSTOM_ID: customization
+:END:
 
 To add your own customization to this configuration, create a configuraton file
 in one of the following directories:

--- a/README.org
+++ b/README.org
@@ -59,6 +59,17 @@ external packages, for example:
   functionality)
 - *Possibly* =vc-mode= by default
 
+** Sensible folder layout
+
+While Emacs tends to keep everything (code, configuration, state files, ...)
+inside `user-emacs-directory` modern computer systems tend to keep those
+separated.
+
+Rational Emacs tries to maintain some balance between those two paradigms by
+bringing just the right amount of order to it.
+
+See [[file:docs/rational-emacs.org#folder-structure][Folder structure]] in the documentation for more details.
+
 ** Works well in the terminal
 
 Some people prefer to use Emacs in the terminal instead of as a graphical

--- a/docs/rational-emacs.info
+++ b/docs/rational-emacs.info
@@ -52,6 +52,7 @@ configuration journey.
 
 * Principles::
 * Why use it?::
+* Folder structure::
 * Customization::
 * Using it with Chemacs2::
 * Contributing::
@@ -185,7 +186,7 @@ principles:
      framework exists.
 
 
-File: rational-emacs.info,  Node: Why use it?,  Next: Customization,  Prev: Principles,  Up: Top
+File: rational-emacs.info,  Node: Why use it?,  Next: Folder structure,  Prev: Principles,  Up: Top
 
 2 Why use it?
 *************
@@ -203,9 +204,32 @@ optional or interchangeable.
 with your own ‘init.el’ file without using this base configuration repo!
 
 
-File: rational-emacs.info,  Node: Customization,  Next: Using it with Chemacs2,  Prev: Why use it?,  Up: Top
+File: rational-emacs.info,  Node: Folder structure,  Next: Customization,  Prev: Why use it?,  Up: Top
 
-3 Customization
+3 Folder structure
+******************
+
+There are two primary folders for working with Rational Emacs:
+
+   • ‘user-emacs-directory‘ (ie: ‘~/.config/emacs‘) where Emacs, by
+     default, searches for its configuration, packages, etc.
+   • ‘rational-config-path‘ (ie: ‘~/.config/rational-emacs‘, see below)
+     where Rational Emacs searches for everything except packages.
+
+   By default Rational Emacs does not do much regarding those paths
+except for customizations as introduced below.
+
+   The ‘rational-config-path‘ layout is designed following current
+common practices to help you keep configuration and runtime data
+separatedly (inside ‘etc/‘ and ‘var/‘ respectively).
+
+   We do not, yet, provide a cache path here as that needs further
+thought (most OS expect caches in specific places).
+
+
+File: rational-emacs.info,  Node: Customization,  Next: Using it with Chemacs2,  Prev: Folder structure,  Up: Top
+
+4 Customization
 ***************
 
 To add your own customization to this configuration, create a
@@ -223,10 +247,10 @@ for the ‘RATIONAL_EMACS_HOME’ environment variable, either on the
 command line or in your shell configuration.  This variable should only
 contain the path to the ‘config.el’ files, for example:
 
-     RATIONAL_EMACS_HOME=~/my-rational-emacs-config
+         RATIONAL_EMACS_HOME=~/my-rational-emacs-config
 
 
-Listing 3.1: Set environment variable ‘RATIONAL_EMACS_HOME’ to the path
+Listing 4.1: Set environment variable ‘RATIONAL_EMACS_HOME’ to the path
 of the configuration directory.
 
 * Menu:
@@ -238,7 +262,7 @@ of the configuration directory.
 
 File: rational-emacs.info,  Node: How the rational config file is found,  Next: Example Configuration,  Up: Customization
 
-3.1 How the rational config file is found
+4.1 How the rational config file is found
 =========================================
 
 The rational config files (‘config.el’ and ‘early-config.el’) are found
@@ -267,29 +291,29 @@ the files ‘config.el’ and ‘early-config.el’ must be created by you.
 
 File: rational-emacs.info,  Node: Example Configuration,  Next: The customel file,  Prev: How the rational config file is found,  Up: Customization
 
-3.2 Example Configuration:
+4.2 Example Configuration:
 ==========================
 
 
-     (require 'rational-defaults)
-     (require 'rational-screencast)
-     (require 'rational-ui)
-     (require 'rational-editing)
-     (require 'rational-evil)
-     (require 'rational-completion)
-     (require 'rational-windows)
+         (require 'rational-defaults)
+         (require 'rational-screencast)
+         (require 'rational-ui)
+         (require 'rational-editing)
+         (require 'rational-evil)
+         (require 'rational-completion)
+         (require 'rational-windows)
 
-     ;; Set further font and theme customizations
-     (custom-set-variables
-      '(rational-ui-default-font
-        '(:font "JetBrains Mono" :weight light :height 185)))
+         ;; Set further font and theme customizations
+         (custom-set-variables
+          '(rational-ui-default-font
+            '(:font "JetBrains Mono" :weight light :height 185)))
 
-     (rational-package-install-package 'doom-themes)
-     (load-theme 'doom-one t)
+         (rational-package-install-package 'doom-themes)
+         (load-theme 'doom-one t)
 
 
 
-Listing 3.2: Example of user created Rational Emacs ‘config.el’ file.
+Listing 4.2: Example of user created Rational Emacs ‘config.el’ file.
 
 See the ‘examples’ folder in the git-repo for more up to date and
 comprehensive examples.
@@ -297,7 +321,7 @@ comprehensive examples.
 
 File: rational-emacs.info,  Node: The customel file,  Prev: Example Configuration,  Up: Customization
 
-3.3 The ‘custom.el’ file
+4.3 The ‘custom.el’ file
 ========================
 
 The ‘custom.el’ file will hold the auto-generated code from the Emacs
@@ -313,7 +337,7 @@ Customization UI.
 
 File: rational-emacs.info,  Node: Simplified overview of how Emacs Customization works,  Next: Loading the customel file,  Up: The customel file
 
-3.3.1 Simplified overview of how Emacs Customization works
+4.3.1 Simplified overview of how Emacs Customization works
 ----------------------------------------------------------
 
 Customizable values are defined with the ‘defcustom’ form, and can be
@@ -344,7 +368,7 @@ the same name (see example below).
 
 File: rational-emacs.info,  Node: Loading the customel file,  Next: Not loading the customel file,  Prev: Simplified overview of how Emacs Customization works,  Up: The customel file
 
-3.3.2 Loading the ‘custom.el’ file
+4.3.2 Loading the ‘custom.el’ file
 ----------------------------------
 
 This is important because if you, the user, wish to use the
@@ -361,7 +385,7 @@ file is *not* automatically loaded by Rational Emacs configuration.  You
 may, if you choose, load this file yourself with the following code in
 your ‘config.el’ file.
 
-     (load "custom")
+           (load "custom")
 
    It is important to load this file last to make sure it overrides any
 values previously set while Emacs was starting.
@@ -369,47 +393,47 @@ values previously set while Emacs was starting.
    If you are using something like the example provided above, you might
 have something that looks more like this:
 
-     (require 'rational-defaults)
-     (require 'rational-screencast)
-     (require 'rational-ui)
-     (require 'rational-editing)
-     (require 'rational-evil)
-     (require 'rational-completion)
-     (require 'rational-windows)
+           (require 'rational-defaults)
+           (require 'rational-screencast)
+           (require 'rational-ui)
+           (require 'rational-editing)
+           (require 'rational-evil)
+           (require 'rational-completion)
+           (require 'rational-windows)
 
-     (rational-package-install-package 'doom-themes)
-     (load-theme 'doom-one t)
+           (rational-package-install-package 'doom-themes)
+           (load-theme 'doom-one t)
 
-     (load "custom")
-     ;;; example-config.el ends here
+           (load "custom")
+           ;;; example-config.el ends here
 
 
-Listing 3.3: Example ‘config.el’ loading the ‘custom.el’ file.
+Listing 4.3: Example ‘config.el’ loading the ‘custom.el’ file.
 
    And then in ‘custom.el’ you would have something like the following
 which is auto-generated by Emacs:
 
-     (custom-set-variables
-      ;; custom-set-variables was added by Custom.
-      ;; If you edit it by hand, you could mess it up, so be careful.
-      ;; Your init file should contain only one such instance.
-      ;; If there is more than one, they won't work right.
-      '(rational-ui-default-font '(:font "JetBrains Mono" :weight light :height 185))
-      '(rational-ui-display-line-numbers t))
-     (custom-set-faces
-      ;; custom-set-faces was added by Custom.
-      ;; If you edit it by hand, you could mess it up, so be careful.
-      ;; Your init file should contain only one such instance.
-      ;; If there is more than one, they won't work right.
-      )
+           (custom-set-variables
+            ;; custom-set-variables was added by Custom.
+            ;; If you edit it by hand, you could mess it up, so be careful.
+            ;; Your init file should contain only one such instance.
+            ;; If there is more than one, they won't work right.
+            '(rational-ui-default-font '(:font "JetBrains Mono" :weight light :height 185))
+            '(rational-ui-display-line-numbers t))
+           (custom-set-faces
+            ;; custom-set-faces was added by Custom.
+            ;; If you edit it by hand, you could mess it up, so be careful.
+            ;; Your init file should contain only one such instance.
+            ;; If there is more than one, they won't work right.
+            )
 
 
-Listing 3.4: Example auto-generated ‘custom.el’ file.
+Listing 4.4: Example auto-generated ‘custom.el’ file.
 
 
 File: rational-emacs.info,  Node: Not loading the customel file,  Next: Caveat on the timing of loading customel,  Prev: Loading the customel file,  Up: The customel file
 
-3.3.3 Not loading the ‘custom.el’ file
+4.3.3 Not loading the ‘custom.el’ file
 --------------------------------------
 
 You may choose not to load the ‘custom.el’ file if you are writing your
@@ -422,29 +446,29 @@ could imply the use of the Customization UI, as our example uses the
 ‘custom-set-variables’ form to set a list of customizable values all at
 once.  Here is the same example written differently.
 
-     (require 'rational-defaults)
-     (require 'rational-screencast)
-     (require 'rational-ui)
-     (require 'rational-editing)
-     (require 'rational-evil)
-     (require 'rational-completion)
-     (require 'rational-windows)
+           (require 'rational-defaults)
+           (require 'rational-screencast)
+           (require 'rational-ui)
+           (require 'rational-editing)
+           (require 'rational-evil)
+           (require 'rational-completion)
+           (require 'rational-windows)
 
-     (customize-set-variable 'rational-ui-default-font
-                             '(:font "JetBrains Mono" :weight light :height 185))
-     (customize-set-variable 'rational-ui-display-line-numbers t)
+           (customize-set-variable 'rational-ui-default-font
+                                   '(:font "JetBrains Mono" :weight light :height 185))
+           (customize-set-variable 'rational-ui-display-line-numbers t)
 
-     (rational-package-install-package 'doom-themes)
-     (load-theme 'doom-one t)
+           (rational-package-install-package 'doom-themes)
+           (load-theme 'doom-one t)
 
 
-Listing 3.5: Example ‘config.el’ setting customization variables
+Listing 4.5: Example ‘config.el’ setting customization variables
 directly.
 
 
 File: rational-emacs.info,  Node: Caveat on the timing of loading customel,  Prev: Not loading the customel file,  Up: The customel file
 
-3.3.4 Caveat on the timing of loading ‘custom.el’
+4.3.4 Caveat on the timing of loading ‘custom.el’
 -------------------------------------------------
 
 Even if you are using emacs-lisp to customize Emacs, you may still
@@ -456,22 +480,22 @@ wins.
 
    Here is an example, first a ‘config.el’ snippet:
 
-     ;; ... some customization before
-     (customize-set-variable 'display-line-numbers-type 'relative)
-     ;; ... some more customization
+           ;; ... some customization before
+           (customize-set-variable 'display-line-numbers-type 'relative)
+           ;; ... some more customization
 
-     (load "custom")
+           (load "custom")
 
 
-Listing 3.6: ‘config.el’ snippet loading ‘custom.el’ last
+Listing 4.6: ‘config.el’ snippet loading ‘custom.el’ last
 
    and the ‘custom.el’ snippet
 
-     (custom-set-variables
-      '(display-line-numbers-type t))
+           (custom-set-variables
+            '(display-line-numbers-type t))
 
 
-Listing 3.7: ‘custom.el’ snippet.
+Listing 4.7: ‘custom.el’ snippet.
 
    The value of the ‘display-line-numbers-type’ will be ‘t’.  Since the
 ‘custom.el’ file is loaded last the first value of the
@@ -483,7 +507,7 @@ set the value only once in your configuration with either
 
 File: rational-emacs.info,  Node: Using it with Chemacs2,  Next: Contributing,  Prev: Customization,  Up: Top
 
-4 Using it with ‘Chemacs2’
+5 Using it with ‘Chemacs2’
 **************************
 
 If you have the ‘Chemacs2’ configuration cloned to ‘~/.emacs.d’ or
@@ -498,11 +522,11 @@ if you installed Rational Emacs to ‘~/.rational-emacs’, then your
 can change the name to something else, see below for examples.
 
 
-     (("rational" . ((user-emacs-directory . "~/path/to/rational-emacs"))))
+         (("rational" . ((user-emacs-directory . "~/path/to/rational-emacs"))))
 
 
 
-Listing 4.1: Example of a ‘Chemacs2’ user profile file in
+Listing 5.1: Example of a ‘Chemacs2’ user profile file in
 ‘~/.emacs-profiles.el’.
 
    If you prefer to put your Rational Emacs customizations elsewhere
@@ -511,23 +535,23 @@ specify the ‘RATIONAL_EMACS_HOME’ environment variable, for example like
 this:
 
 
-     (("rational" . ((user-emacs-directory . "~/path/to/rational-emacs")
-                     (env . (("RATIONAL_EMACS_HOME" . "~/path/to/rational-emacs/personal"))))))
+           (("rational" . ((user-emacs-directory . "~/path/to/rational-emacs")
+                           (env . (("RATIONAL_EMACS_HOME" . "~/path/to/rational-emacs/personal"))))))
 
 
 
-Listing 4.2: User ‘Chemacs2’ profile file ‘~/.emacs-profiles.el’ with
+Listing 5.2: User ‘Chemacs2’ profile file ‘~/.emacs-profiles.el’ with
 environment variable.
 
    Or some place completely different:
 
 
-     (("rational" . ((user-emacs-directory . "~/path/to/rational-emacs")
-                     (env . (("RATIONAL_EMACS_HOME" . "~/rational-config/personal"))))))
+           (("rational" . ((user-emacs-directory . "~/path/to/rational-emacs")
+                           (env . (("RATIONAL_EMACS_HOME" . "~/rational-config/personal"))))))
 
 
 
-Listing 4.3: User ‘Chemacs2’ profile file ‘~/.emacs-profiles.el’ with
+Listing 5.3: User ‘Chemacs2’ profile file ‘~/.emacs-profiles.el’ with
 Rational Emacs config files set to another path.
 
    Then launch it with ‘emacs --with-profile rational’!
@@ -535,7 +559,7 @@ Rational Emacs config files set to another path.
 
 File: rational-emacs.info,  Node: Contributing,  Next: Modules,  Prev: Using it with Chemacs2,  Up: Top
 
-5 Contributing
+6 Contributing
 **************
 
 Follow the Elisp Style Guide
@@ -553,7 +577,7 @@ SystemCrafters (https://systemcrafters.net/) community!
 
 File: rational-emacs.info,  Node: Modules,  Next: Troubleshooting,  Prev: Contributing,  Up: Top
 
-6 Modules
+7 Modules
 *********
 
 Rational Emacs includes a number of modules to further configure Emacs.
@@ -586,12 +610,12 @@ the module of interest to understand it best.
 
 File: rational-emacs.info,  Node: Rational Emacs Completion Module,  Next: Rational Emacs Defaults Module,  Up: Modules
 
-6.1 Rational Emacs Completion Module
+7.1 Rational Emacs Completion Module
 ====================================
 
 To use this module, simply require it in your config.
 
-     (require 'rational-completion)
+         (require 'rational-completion)
 
    This module installs and sets up a set of completion-related packages
 that work together to achieve a functionality that you might know from
@@ -796,12 +820,12 @@ the five packages come in.
 
 File: rational-emacs.info,  Node: Rational Emacs Defaults Module,  Next: Rational Emacs Editing Module,  Prev: Rational Emacs Completion Module,  Up: Modules
 
-6.2 Rational Emacs Defaults Module
+7.2 Rational Emacs Defaults Module
 ==================================
 
 To use this module, simply require it in your config.
 
-     (require 'rational-defaults)
+         (require 'rational-defaults)
 
    • ‘global-auto-revert-non-file-buffers’ : ‘t’
 
@@ -812,7 +836,7 @@ To use this module, simply require it in your config.
      Change this setting either by finding it in the Customization UI or
      by adding this code to your ‘config.el’
 
-          (customize-set-variable 'global-auto-revert-non-file-buffers nil)
+                (customize-set-variable 'global-auto-revert-non-file-buffers nil)
 
    • ‘global-auto-revert-mode’
 
@@ -821,7 +845,7 @@ To use this module, simply require it in your config.
 
      Turn this off by adding this code to your ‘config.el’
 
-          (global-auto-revert-mode -1)
+                (global-auto-revert-mode -1)
 
    • ‘indent-tabs-mode’ : ‘nil’
 
@@ -830,7 +854,7 @@ To use this module, simply require it in your config.
      Change this setting either by finding it in the Customization UI or
      by adding this code to your ‘config.el’
 
-          (customize-set-variable 'indent-tabs-mode t)
+                (customize-set-variable 'indent-tabs-mode t)
 
    • ‘y-or-n-p’
 
@@ -838,7 +862,7 @@ To use this module, simply require it in your config.
      This is managed by Emacs advice functionality.  It can be reverted
      in your ‘config.el’ by adding the code:
 
-          (advice-remove 'yes-or-no-p #'y-or-n-p)
+                (advice-remove 'yes-or-no-p #'y-or-n-p)
 
      In Emacs versions beginning with 28, use the ‘use-short-answers’
      variable set to ‘t’ instead to accomplish the same thing.
@@ -865,7 +889,7 @@ To use this module, simply require it in your config.
      by adding this code to your ‘config.el’ (make sure to set the path
      correctly)
 
-          (customize-set-variable 'recentf-save-file "/some/path/to/recentf")
+                (customize-set-variable 'recentf-save-file "/some/path/to/recentf")
 
    • ‘kill-do-not-save-duplicates’ : ‘t’
 
@@ -876,7 +900,7 @@ To use this module, simply require it in your config.
      Change this setting either by finding it in the Customization UI or
      by adding this code to your ‘config.el’
 
-          (customize-set-variable 'kill-do-not-save-duplicates nil)
+                (customize-set-variable 'kill-do-not-save-duplicates nil)
 
    • ‘auto-window-vscroll’ : ‘nil’
 
@@ -885,7 +909,7 @@ To use this module, simply require it in your config.
 
      Change this by adding this code to your ‘config.el’
 
-          (setq auto-window-vscroll t)
+                (setq auto-window-vscroll t)
 
    • ‘fast-but-imprecise-scrolling’ : ‘t’
 
@@ -896,7 +920,7 @@ To use this module, simply require it in your config.
      Change this setting either by finding it in the Customization UI or
      by adding this code to your ‘config.el’
 
-          (customize-set-variable 'fast-but-imprecise-scrolling nil)
+                (customize-set-variable 'fast-but-imprecise-scrolling nil)
 
    • ‘scroll-conservatively’ : ‘101’
 
@@ -909,7 +933,7 @@ To use this module, simply require it in your config.
      code to your ‘config.el’ where ‘nnn’ is some number of lines to
      scroll.
 
-          (customize-set-variable 'scroll-conservatively nnn)
+                (customize-set-variable 'scroll-conservatively nnn)
 
    • ‘scroll-margin’ : ‘0’
 
@@ -920,7 +944,7 @@ To use this module, simply require it in your config.
      your ‘custom.el’ where ‘nn’ is some number of lines at the top or
      bottom of a buffer where scrolling should start (for example: 5)
 
-          (customize-set-variable 'scroll-margin nn)
+                (customize-set-variable 'scroll-margin nn)
 
    • ‘scroll-preserve-screen-position’ : ‘t’
 
@@ -934,7 +958,7 @@ To use this module, simply require it in your config.
      Change this value in the Customization UI or by adding this code to
      ‘custom.el’
 
-          (customize-set-variable 'scroll-preserve-screen-position nil)
+                (customize-set-variable 'scroll-preserve-screen-position nil)
 
    • ‘bidi-paragraph-direction’ : ‘left-to-right’
 
@@ -944,7 +968,7 @@ To use this module, simply require it in your config.
      You can change this through the Customization UI or by addding the
      following code in ‘config.el’
 
-          (customize-set-variable 'bidi-paragraph-direction 'right-to-left)
+                (customize-set-variable 'bidi-paragraph-direction 'right-to-left)
 
    • ‘bidi-inhibit-bpa’ : ‘t’
 
@@ -952,14 +976,14 @@ To use this module, simply require it in your config.
      which makes redisplay faster.  You can change the value of this
      variable by adding this code to ‘custom.el’
 
-          (setq bidi-inhibit-bpa nil)
+                (setq bidi-inhibit-bpa nil)
 
    • ‘global-so-long-mode’
 
      Improves performance for files with excessively long lines.  This
      can minor mode can be turned off in ‘config.el’ by adding:
 
-          (global-so-long-mode -1)
+                (global-so-long-mode -1)
 
    • ‘executable-make-buffer-file-executable-if-script-p’
 
@@ -967,7 +991,7 @@ To use this module, simply require it in your config.
      saving the file.  To remove this behavior add the following to
      ‘config.el’
 
-          (remove-hook 'after-save-hook 'executable-make-buffer-file-executable-if-script-p)
+                (remove-hook 'after-save-hook 'executable-make-buffer-file-executable-if-script-p)
 
    • ‘savehist-mode’
 
@@ -976,22 +1000,22 @@ To use this module, simply require it in your config.
      You can change where the file should live with the Customization UI
      or by adding the following to ‘config.el’
 
-          (customize-set-variable 'savehist-file
-                                  "/path/to/minibuffer/history/file")
+                (customize-set-variable 'savehist-file
+                                        "/path/to/minibuffer/history/file")
 
      You can turn off this mode by adding this code to ‘config.el’
 
-          (savehist-mode -1)
+                (savehist-mode -1)
 
 
 File: rational-emacs.info,  Node: Rational Emacs Editing Module,  Next: Rational Emacs Lisp Module,  Prev: Rational Emacs Defaults Module,  Up: Modules
 
-6.3 Rational Emacs Editing Module
+7.3 Rational Emacs Editing Module
 =================================
 
 To use this module, simply require it in your config.
 
-     (require 'rational-editing)
+         (require 'rational-editing)
 
    • Whitespace
 
@@ -1030,12 +1054,12 @@ To use this module, simply require it in your config.
      for more options.  This variable can be changed through the
      Customization UI or by adding to ‘config.el’
 
-          ;; change the list of options to be what you wish based on the values
-          ;; mentioned in the commentary for this variable
-          ;; (C-h v whitespace-style RET)
-          (customize-set-variable 'whitespace-style
-                                  '(face tabs empty trailing tab-mark
-                                         indentation::space))
+                ;; change the list of options to be what you wish based on the values
+                ;; mentioned in the commentary for this variable
+                ;; (C-h v whitespace-style RET)
+                (customize-set-variable 'whitespace-style
+                                        '(face tabs empty trailing tab-mark
+                                               indentation::space))
 
    • ‘whitespace-action’ : ‘(cleanup auto-cleanup)’
 
@@ -1054,17 +1078,17 @@ To use this module, simply require it in your config.
      RET’) for more options.  This variable can be changed through the
      Customization UI or by adding to ‘config.el’
 
-          ;; change the list of options to be what you wish based on the values
-          ;; mentioned in the commentary for this variable
-          ;; (C-h v whitespace-action RET)
-          (customize-set-variable 'whitespace-action '(cleanup auto-cleanup))
+                ;; change the list of options to be what you wish based on the values
+                ;; mentioned in the commentary for this variable
+                ;; (C-h v whitespace-action RET)
+                (customize-set-variable 'whitespace-action '(cleanup auto-cleanup))
 
    • ‘whitespace-mode’
 
      This minor mode is added to ‘prog-mode’ and ‘text-mode’ via hooks.
      To change this, add code similar to the following to ‘config.el’
 
-          (remove-hook 'prog-mode-hook #'whitespace-mode)
+                (remove-hook 'prog-mode-hook #'whitespace-mode)
 
    • ‘electric-pair-mode’
 
@@ -1079,15 +1103,15 @@ To use this module, simply require it in your config.
 
      This can be turned off by adding this code to ‘config.el’
 
-          (electric-pair-mode -1)
+                (electric-pair-mode -1)
 
      Alternatively, if this should only apply to certain modes,
      programming language modes for example, this code would be used:
 
-          (electric-pair-mode -1)                         ; turn off globally
+                (electric-pair-mode -1)                         ; turn off globally
 
-          (add-hook 'prog-mode-hook #'electric-pair-mode) ; turn on only for
-                                                          ; programming modes
+                (add-hook 'prog-mode-hook #'electric-pair-mode) ; turn on only for
+                                                                ; programming modes
 
    • ‘show-paren-mode’
 
@@ -1096,20 +1120,20 @@ To use this module, simply require it in your config.
 
      This can be turned off by adding this code to ‘config.el’
 
-          (show-paren-mode -1)
+                (show-paren-mode -1)
 
      Alternatively, if this should only apply to certain modes,
      programming language modes for example, this code would be used:
 
-          (show-paren-mode -1)                         ; turn off globally
+                (show-paren-mode -1)                         ; turn off globally
 
-          (add-hook 'prog-mode-hook #'show-paren-mode) ; turn on only for
-                                                       ; programming modes
+                (add-hook 'prog-mode-hook #'show-paren-mode) ; turn on only for
+                                                             ; programming modes
 
 
 File: rational-emacs.info,  Node: Rational Emacs Lisp Module,  Next: Rational Emacs IDE Module,  Prev: Rational Emacs Editing Module,  Up: Modules
 
-6.4 Rational Emacs Lisp Module
+7.4 Rational Emacs Lisp Module
 ==============================
 
 This module installs and configures a few additonal packages to provide
@@ -1181,7 +1205,7 @@ Clojure, Scheme, and Racket.
 
 File: rational-emacs.info,  Node: Packages Installed,  Next: Common,  Up: Rational Emacs Lisp Module
 
-6.4.1 Packages Installed
+7.4.1 Packages Installed
 ------------------------
 
    • Common
@@ -1204,7 +1228,7 @@ File: rational-emacs.info,  Node: Packages Installed,  Next: Common,  Up: Ration
 
 File: rational-emacs.info,  Node: Common,  Next: Common Lisp,  Prev: Packages Installed,  Up: Rational Emacs Lisp Module
 
-6.4.2 Common
+7.4.2 Common
 ------------
 
 Aggressive indent mode is added to each of the other lisp family
@@ -1212,7 +1236,7 @@ configurations.  It provides automatic indentation, even when pasting
 code or adding structure.  It is added on each mode hook, to turn this
 feature off, remove the hook.  For example:
 
-     (remove-hook 'lisp-mode-hook #'aggressive-indent-mode)
+          (remove-hook 'lisp-mode-hook #'aggressive-indent-mode)
 
    • Hooks ‘aggressive-mode’ is added to:
         • ‘lisp-mode-hook’
@@ -1222,7 +1246,7 @@ feature off, remove the hook.  For example:
 
 File: rational-emacs.info,  Node: Common Lisp,  Next: Clojure,  Prev: Common,  Up: Rational Emacs Lisp Module
 
-6.4.3 Common Lisp
+7.4.3 Common Lisp
 -----------------
 
 The configuration for Common Lisp features Sylvester the cat’s Common
@@ -1232,7 +1256,7 @@ completion, integration with ASDF and Quicklsp system definition tools.
 
 File: rational-emacs.info,  Node: Clojure,  Next: Scheme/Racket,  Prev: Common Lisp,  Up: Rational Emacs Lisp Module
 
-6.4.4 Clojure
+7.4.4 Clojure
 -------------
 
 The configuration for Clojure is based on CIDER and adds ‘clj-refactor’
@@ -1241,12 +1265,12 @@ prefix is set to ‘C-c r’ to avoid conflicts with CIDER.  To change this
 to something else (for example ‘C-c C-m’ as mentioned on the github
 page) use the following snippet:
 
-     (clj-add-keybindings-with-prefix "C-c C-m")
+          (clj-add-keybindings-with-prefix "C-c C-m")
 
 
 File: rational-emacs.info,  Node: Scheme/Racket,  Prev: Clojure,  Up: Rational Emacs Lisp Module
 
-6.4.5 Scheme/Racket
+7.4.5 Scheme/Racket
 -------------------
 
 Geiser provides a modular package for the Scheme family of languages
@@ -1265,12 +1289,12 @@ to set the ‘scheme-program-name’ variable, which we default to "guile"
 to match the configuration for that implementation.  To change this to
 ‘scheme’ for example, use this snippet:
 
-     (customize-set-variable 'scheme-program-name "scheme")
+          (customize-set-variable 'scheme-program-name "scheme")
 
 
 File: rational-emacs.info,  Node: Rational Emacs IDE Module,  Next: Rational Emacs Project Module,  Prev: Rational Emacs Lisp Module,  Up: Modules
 
-6.5 Rational Emacs IDE Module
+7.5 Rational Emacs IDE Module
 =============================
 
 This module is a generic module which installs and configures Eglot for
@@ -1285,24 +1309,24 @@ config.
 
 File: rational-emacs.info,  Node: Provided configuration,  Up: Rational Emacs IDE Module
 
-6.5.1 Provided configuration
+7.5.1 Provided configuration
 ----------------------------
 
 ‘eglot-autoshutdown’ is set to ‘t’ to cause Eglot to shutdown the
 language server(s) in use when the last buffer using one is killed.  Set
 this to ‘nil’ to keep the LSP servers running.
 
-     (customize-set-variable 'eglot-autoshutdown nil)
+          (customize-set-variable 'eglot-autoshutdown nil)
 
 
 File: rational-emacs.info,  Node: Rational Emacs Project Module,  Next: Rational Emacs Python Module,  Prev: Rational Emacs IDE Module,  Up: Modules
 
-6.6 Rational Emacs Project Module
+7.6 Rational Emacs Project Module
 =================================
 
 To use this module, simply require it in your config.
 
-     (require 'rational-project)
+         (require 'rational-project)
 
    This module uses Emacs’ built-in project backend (often referred to
 as ‘project.el’).
@@ -1328,7 +1352,7 @@ for details.
 
 File: rational-emacs.info,  Node: Rational Emacs Python Module,  Prev: Rational Emacs Project Module,  Up: Modules
 
-6.7 Rational Emacs Python Module
+7.7 Rational Emacs Python Module
 ================================
 
 This module installs a few additional packages to configure an IDE-like
@@ -1345,7 +1369,7 @@ module, simply require it in your config.
 
 File: rational-emacs.info,  Node: Packages Installed (1),  Next: Provided configuration (1),  Up: Rational Emacs Python Module
 
-6.7.1 Packages Installed
+7.7.1 Packages Installed
 ------------------------
 
    • ‘anaconda-mode’
@@ -1357,7 +1381,7 @@ File: rational-emacs.info,  Node: Packages Installed (1),  Next: Provided config
      This mode is used to format your Python code on-save.  You also
      need to install the ‘black’ package with ‘pip’:
 
-          pip install black
+                 pip install black
 
    • ‘eglot’
 
@@ -1366,7 +1390,7 @@ File: rational-emacs.info,  Node: Packages Installed (1),  Next: Provided config
      features.  You also need to install the ‘pyright’ package with
      ‘pip’:
 
-          pip install pyright
+                 pip install pyright
 
    • ‘numpydoc’
 
@@ -1381,7 +1405,7 @@ File: rational-emacs.info,  Node: Packages Installed (1),  Next: Provided config
 
 File: rational-emacs.info,  Node: Provided configuration (1),  Next: Suggested keybindings,  Prev: Packages Installed (1),  Up: Rational Emacs Python Module
 
-6.7.2 Provided configuration
+7.7.2 Provided configuration
 ----------------------------
 
 ‘anaconda-mode-installation-directory’ is set to the
@@ -1412,7 +1436,7 @@ with each variable.
 
 File: rational-emacs.info,  Node: Suggested keybindings,  Prev: Provided configuration (1),  Up: Rational Emacs Python Module
 
-6.7.3 Suggested keybindings
+7.7.3 Suggested keybindings
 ---------------------------
 
 No keybindings are provided, but we do offer the following suggestions.
@@ -1420,20 +1444,20 @@ No keybindings are provided, but we do offer the following suggestions.
    Using the ‘with-eval-after-load’ form defers loading the keybindings
 until the module is loaded (either "python" or "pyvenv" in this case).
 
-     (with-eval-after-load "python"
-       (define-key python-mode-map (kbd "C-c C-n") #'numpydoc-generate)
-       (define-key python-mode-map (kbd "C-c e n") #'flymake-goto-next-error)
-       (define-key python-mode-map (kbd "C-c e p") #'flymake-goto-prev-error))
+          (with-eval-after-load "python"
+            (define-key python-mode-map (kbd "C-c C-n") #'numpydoc-generate)
+            (define-key python-mode-map (kbd "C-c e n") #'flymake-goto-next-error)
+            (define-key python-mode-map (kbd "C-c e p") #'flymake-goto-prev-error))
 
-     (with-eval-after-load "pyvenv"
-       (define-key pyvenv-mode-map (kbd "C-c p a") #'pyvenv-activate)
-       (define-key pyvenv-mode-map (kbd "C-c p d") #'pyvenv-deactivate)
-       (define-key pyvenv-mode-map (kbd "C-c p w") #'pyvenv-workon))
+          (with-eval-after-load "pyvenv"
+            (define-key pyvenv-mode-map (kbd "C-c p a") #'pyvenv-activate)
+            (define-key pyvenv-mode-map (kbd "C-c p d") #'pyvenv-deactivate)
+            (define-key pyvenv-mode-map (kbd "C-c p w") #'pyvenv-workon))
 
 
 File: rational-emacs.info,  Node: Troubleshooting,  Next: MIT License,  Prev: Modules,  Up: Top
 
-7 Troubleshooting
+8 Troubleshooting
 *****************
 
 Some tips when things don’t seem to work right.
@@ -1445,7 +1469,7 @@ Some tips when things don’t seem to work right.
 
 File: rational-emacs.info,  Node: A package (suddenly?) fails to work,  Up: Troubleshooting
 
-7.1 A package (suddenly?) fails to work
+8.1 A package (suddenly?) fails to work
 =======================================
 
 This scenario happened frequently when upgading to Emacs 28.  It also
@@ -1501,7 +1525,7 @@ these actions in your configuration:
           offending package to MELPA (make sure to replace
           _package-name_ with the name of the actual package):
 
-               (add-to-list 'package-pinned-packages (cons 'package-name "melpa"))
+                        (add-to-list 'package-pinned-packages (cons 'package-name "melpa"))
 
         • Use ‘M-x package-list-packages’ to display the list of
           packages.
@@ -1548,48 +1572,49 @@ Appendix A MIT License
 
 Tag Table:
 Node: Top1412
-Node: Principles3554
-Node: Why use it?6621
-Node: Customization7297
-Ref: org43c131e8101
-Node: How the rational config file is found8389
-Node: Example Configuration9845
-Ref: org2f82ab910051
-Node: The customel file10712
-Node: Simplified overview of how Emacs Customization works11259
-Node: Loading the customel file12979
-Ref: configel14283
-Ref: customel14840
-Node: Not loading the customel file15572
-Ref: org680c7dc16456
-Node: Caveat on the timing of loading customel17056
-Ref: configel (1)17723
-Ref: customel (1)17991
-Node: Using it with Chemacs218498
-Ref: org00661c519319
-Ref: org81acaf319722
-Ref: orgaead2f120036
-Node: Contributing20391
-Node: Modules21029
-Node: Rational Emacs Completion Module22229
-Node: Rational Emacs Defaults Module31624
-Node: Rational Emacs Editing Module38772
-Node: Rational Emacs Lisp Module43466
-Node: Packages Installed46090
-Node: Common46679
-Node: Common Lisp47295
-Node: Clojure47652
-Node: Scheme/Racket48180
-Node: Rational Emacs IDE Module49176
-Node: Provided configuration49647
-Node: Rational Emacs Project Module50052
-Node: Rational Emacs Python Module51173
-Node: Packages Installed (1)51742
-Node: Provided configuration (1)52744
-Node: Suggested keybindings54067
-Node: Troubleshooting54988
-Node: A package (suddenly?) fails to work55225
-Node: MIT License59035
+Node: Principles3575
+Node: Why use it?6642
+Node: Folder structure7321
+Node: Customization8253
+Ref: org8d951339062
+Node: How the rational config file is found9354
+Node: Example Configuration10810
+Ref: org2422c9811016
+Node: The customel file11729
+Node: Simplified overview of how Emacs Customization works12276
+Node: Loading the customel file13996
+Ref: configel15306
+Ref: customel15929
+Node: Not loading the customel file16739
+Ref: org8fd1aea17623
+Node: Caveat on the timing of loading customel18295
+Ref: configel (1)18962
+Ref: customel (1)19254
+Node: Using it with Chemacs219773
+Ref: orgb2f540d20594
+Ref: org987c43921001
+Ref: orgf4ba83121327
+Node: Contributing21694
+Node: Modules22332
+Node: Rational Emacs Completion Module23532
+Node: Rational Emacs Defaults Module32931
+Node: Rational Emacs Editing Module40191
+Node: Rational Emacs Lisp Module45003
+Node: Packages Installed47627
+Node: Common48216
+Node: Common Lisp48837
+Node: Clojure49194
+Node: Scheme/Racket49727
+Node: Rational Emacs IDE Module50728
+Node: Provided configuration51199
+Node: Rational Emacs Project Module51609
+Node: Rational Emacs Python Module52734
+Node: Packages Installed (1)53303
+Node: Provided configuration (1)54319
+Node: Suggested keybindings55642
+Node: Troubleshooting56603
+Node: A package (suddenly?) fails to work56840
+Node: MIT License60659
 
 End Tag Table
 

--- a/docs/rational-emacs.org
+++ b/docs/rational-emacs.org
@@ -110,6 +110,19 @@ Emacs configuration journey.
   with your own =init.el= file without using this base configuration
   repo!
 
+* Folder structure
+
+  There are two primary folders for working with Rational Emacs:
+
+  - `user-emacs-directory` (ie: `~/.config/emacs`) where Emacs, by default, searches for its configuration, packages, etc.
+  - `rational-config-path` (ie: `~/.config/rational-emacs`, see below) where Rational Emacs searches for everything except packages.
+
+  By default Rational Emacs does not do much regarding those paths except for customizations as introduced below.
+
+  The `rational-config-path` layout is designed following current common practices to help you keep configuration and runtime data separatedly (inside `etc/` and `var/` respectively).
+
+  We do not, yet, provide a cache path here as that needs further thought (most OS expect caches in specific places).
+
 * Customization
 
   To add your own customization to this configuration, create a


### PR DESCRIPTION
#158 would need this introduction to build upon it.

Using a separate PR as those are two different concerns:

1. Rational Emacs folder layout (this PR)
2. Extending on the folder layout to bring runtime & config data into `rational-config-path` (#158)

I'll later update #158