### PR TITLE
Fix doom-modeline initialization

### DIFF
--- a/modules/rational-ui.el
+++ b/modules/rational-ui.el
@@ -68,7 +68,7 @@ Use a plist with the same key names as accepted by `set-face-attribute'."
 ;;;; Mode-Line
 
 ;; Start up the modeline after initialization is finished
-(add-hook 'after-init-hook 'doom-modeline-init)
+(add-hook 'after-init-hook 'doom-modeline-mode)
 
 ;; Configure `doom-modeline'
 (customize-set-variable 'doom-modeline-height 15)


### PR DESCRIPTION
`doom-modeline-init` function was removed in commit https://github.com/seagle0128/doom-modeline/commit/11faebc1f9239302eb4c431448aff0143005610b, use `doom-modeline-mode` instead