### PR TITLE
Cleaning up some redundant keys from rational-osx

### DIFF
--- a/modules/rational-osx.el
+++ b/modules/rational-osx.el
@@ -1,6 +1,6 @@
 ;;; rational-osx.el --- osx specific config -*- lexical-binding: t -*-
 
-;; Copyright (C) 2022
+;; Copyright (C) 2022 
 ;; SPDX-License-Identifier: MIT
 
 ;; Author: System Crafters Community
@@ -25,31 +25,27 @@
 ;; titlebar
 
   (when rational-osx-transparent-titlebar
-    (setq frame-resize-pixelwise t)
+    (customize-set-variable frame-resize-pixelwise t)
     (add-to-list 'default-frame-alist '(ns-transparent-titlebar . t))
     (add-to-list 'default-frame-alist '(selected-frame) 'name nil)
     (add-to-list 'default-frame-alist '(ns-appearance . dark))) ;; assuming a dark theme is in use
 
 ;; Special keys
 
-  (setq mac-right-option-modifier nil)
-  (setq mac-command-modifier 'hyper)
+  (customize-set-variable mac-right-option-modifier nil)
+  (customize-set-variable mac-command-modifier 'super)
+  (customize-set-variable ns-function-modifier 'hyper)
 
 ;; Keybinds
 
-  (global-set-key (kbd "H-c") 'kill-ring-save) ; ⌘-c = Copy
-  (global-set-key (kbd "H-s") 'save-buffer) ; ⌘-s = Save
-  (global-set-key (kbd "H-v") 'yank) ; ⌘-v = Paste
-  (global-set-key (kbd "H-f") 'kill-region) ; ⌘-x = Cut
-  (global-set-key (kbd "H-a") 'mark-whole-buffer) ; ⌘-a = Select all
-  (global-set-key (kbd "H-z") 'undo) ; ⌘-z = Undo
-  (global-set-key (kbd "H-q") 'kill-emacs) ; ⌘-q = Quit Emacs
-  (global-set-key (kbd "H-n") 'make-frame) ; ⌘-n = New window
-  (global-set-key (kbd "H-w") 'delete-frame) ; ⌘-t = Close window
-  (global-set-key (kbd "H-`") 'ns-next-frame) ; ⌘-` = Next visible frame
-  (global-set-key (kbd "H-}") 'tab-bar-switch-to-next-tab) ; ⌘-} = Next tab
-  (global-set-key (kbd "H-{") 'tab-bar-switch-to-prev-tab) ; ⌘-{ = Previous tab
-  (global-set-key (kbd "H-t") 'tab-bar-new-tab) ; ⌘-t = New tab
+  (global-set-key (kbd "s-W") 'delete-frame) ; ⌘-W = Close window
+  (global-set-key (kbd "s-}") 'tab-bar-switch-to-next-tab) ; ⌘-} = Next tab
+  (global-set-key (kbd "s-{") 'tab-bar-switch-to-prev-tab) ; ⌘-{ = Previous tab
+  (global-set-key (kbd "s-t") 'tab-bar-new-tab) ;⌘-t = New tab
+  (global-set-key (kbd "s-w") 'tab-bar-close-tab) ; ⌘-w = Close tab
+
+  (unless (< emacs-major-version 28)
+    (global-set-key (kbd "s-Z") 'undo-redo)) ; ⌘-Z = Redo
 
 ;; Better compatibility with osx based window managers
 


### PR DESCRIPTION
After testing a bit more with Emacs without configuration, I realize that most of the keys I mapped were already mapped, and that Emacs, by default, uses command as super. For this reason, I deleted a lot of the redundant keybindings and switch to super instead of hyper for the command key.