### PR TITLE
Changed variable in rational-org.el

### DIFF
--- a/modules/rational-org.el
+++ b/modules/rational-org.el
@@ -18,7 +18,7 @@
 (customize-set-variable 'org-mouse-1-follows-link t)
 
 ;; Display links as the description provided
-(customize-set-variable 'org-descriptive-links t)
+(customize-set-variable 'org-link-descriptive t)
 
 ;; Hide markup markers
 (customize-set-variable 'org-hide-emphasis-markers t)


### PR DESCRIPTION
org-descriptive-links was changed to org-link-descriptive as the
former is stated to be obsolete since version 9.3 per the Helpful
documentation.

This addresses issue #183.